### PR TITLE
Добавлен prefers-reduce-motion в мобильное меню

### DIFF
--- a/src/styles/blocks/page.css
+++ b/src/styles/blocks/page.css
@@ -51,6 +51,12 @@
     transition: transform 0.2s linear;
 }
 
+@media (prefers-reduced-motion: reduce) {
+    .page__content {
+        transition: none;
+    }
+}
+
 @media (min-width: 1024px) {
     .page__content--inner {
         grid-row: 1 / 3;


### PR DESCRIPTION
Если у пользователя в настройках ОС установлено пожелание не использовать анимации, определять это с помощью медиа выражения `prefers-reduce-motion: reduce` и выключать анимацию.