### PR TITLE
Изменяет сетку статьи

### DIFF
--- a/src/styles/blocks/article.css
+++ b/src/styles/blocks/article.css
@@ -14,7 +14,7 @@
     .article {
         display: grid;
         grid-template-rows: 1fr min-content;
-        grid-template-columns: repeat(8, 1fr) calc(100vw - 1800px);
+        grid-template-columns: repeat(8, 1fr);
     }
 }
 
@@ -277,7 +277,7 @@
 @media (min-width: 1240px) {
     .article__authors {
         grid-row: 2 / -1;
-        grid-column: 1 / 5;
+        grid-column: 1 / 3;
     }
 }
 
@@ -294,6 +294,6 @@
 @media (min-width: 1240px) {
     .article__content  {
         grid-row: 2 / -1;
-        grid-column: 5 / -2;
+        grid-column: 3 / -2;
     }
 }


### PR DESCRIPTION
Fix #30 

Уменьшил ширину боковой части контента и увеличил ширину самой статьи.

Было (разрешение 2560px):

![80630559-7bb4d500-8a65-11ea-922c-12716658d30b](https://user-images.githubusercontent.com/48956742/80667953-b735ba80-8aca-11ea-8fb2-b53737e98da8.jpg)

Стало (разрешение 2560px):

![Аннотация 2020-04-30 100346](https://user-images.githubusercontent.com/48956742/80667769-40002680-8aca-11ea-8392-ac85f250e845.png)