### PR TITLE
Правит блок с видео при загрузке

### DIFF
--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -321,7 +321,7 @@
     border-radius: 24px;
 }
 
-.content iframe {
+.content > iframe {
     display: block;
     width: 100%;
     min-height: 400px;

--- a/src/styles/blocks/video.css
+++ b/src/styles/blocks/video.css
@@ -2,6 +2,7 @@
     position: relative;
     width: 100%;
     height: 0;
+    margin-top: 16px;
     padding-bottom: 56.25%;
     background-color: #000000;
 }


### PR DESCRIPTION
При загрузке видео `iframe` цеплял стили из `content.css` с минимальной высотой в `400px` и наезжал на нижние блоки с текстом.
До загрузки: 
![image](https://user-images.githubusercontent.com/28845333/80741979-42429f00-8b23-11ea-837f-792bf4dd06b8.png)
После:
![image](https://user-images.githubusercontent.com/28845333/80742020-58505f80-8b23-11ea-84a1-b5d492acdc6c.png)

Поправил селекторы, добавил отступ сверху, получилось так:
![image](https://user-images.githubusercontent.com/28845333/80742139-93eb2980-8b23-11ea-822a-e055a877b2d0.png)



