### PR TITLE
Изменяет цвет ссылок в меню

### DIFF
--- a/src/layouts/page.njk
+++ b/src/layouts/page.njk
@@ -31,9 +31,14 @@
                 type="button">
                 <span class="navigation__inner"></span>
             </button>
+            {% if page.url == '/articles/' %}
+                {% set articlesClass = 'navigation__link--active' %}
+            {% else %}
+                {% set articlesHref = 'href="/articles/"' %}
+            {% endif %}
             <ul class="navigation__menu" id="navigation-menu">
                 <li class="navigation__item">
-                    <a class="navigation__link {% if page.url == '/articles/' %}navigation__link--active{% endif %}" href="/articles/">Статьи</a>
+                    <a class="navigation__link {{ articlesClass }}" {{ articlesHref | safe }}>Статьи</a>
                 </li>
                 <li class="navigation__item">
                     <a class="navigation__link">Календарь</a>

--- a/src/styles/blocks/navigation.css
+++ b/src/styles/blocks/navigation.css
@@ -336,6 +336,7 @@
 }
 
 .navigation__link--active {
+    color: black;
     font-family: 'Dewi Expanded', sans-serif;
     font-weight: bold;
 }

--- a/src/styles/blocks/navigation.css
+++ b/src/styles/blocks/navigation.css
@@ -341,11 +341,12 @@
 }
 
 .navigation__link[href]:link {
-    color: black;
+    color: var(--color-blue-medium);
+    text-decoration: underline;
 }
 
 .navigation__link[href]:visited {
-    color: black;
+    color: var(--color-blue-medium);
 }
 
 @media (hover: hover) and (pointer: fine) {

--- a/src/styles/blocks/navigation.css
+++ b/src/styles/blocks/navigation.css
@@ -307,7 +307,7 @@
 .navigation__link {
     font-size: 14px;
     line-height: 1.2;
-    color: var(--color-grey-lighter);
+    color: var(--color-grey-medium);
     letter-spacing: 0.02em;
     text-decoration: none;
     text-transform: uppercase;

--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -38,7 +38,7 @@
     --color-blue-lightest: #def3f6;
     --color-blue-lightest-transparent: #def3f600;
     --color-blue-light: #32adfd;
-    --color-blue-medium: #26649f;
+    --color-blue-medium: #377db3;
     --color-blue-darker: #0064a4;
 
     --color-green-light: #ddf2ea;


### PR DESCRIPTION
Fix #24 

Изменил цвет ссылок меню.
Переменная `--color-blue-medium` нигде не использовалась, поэтому заменил цвет в ней, чтобы не создавать новую (и цвет `#377db3` явно светлее, чем `#26649f`).