### PR TITLE
Исправляет отображение дополнительных статей на мобильных

### DIFF
--- a/src/styles/blocks/articles.css
+++ b/src/styles/blocks/articles.css
@@ -59,7 +59,7 @@
 
 /* Related */
 
-@media (min-width: 900px) {
+@media (min-width: 800px) {
     .articles--related {
         display: grid;
         grid-template-columns: 1fr 1fr 1fr;


### PR DESCRIPTION
Сделал отображение дополнительных статей чуть красивее на разрешении 800+

Было: 

![1](https://user-images.githubusercontent.com/48956742/80921259-87730500-8d9f-11ea-9705-5c9aac03a6bf.png)

Стало:

![2](https://user-images.githubusercontent.com/48956742/80921260-88a43200-8d9f-11ea-8d13-2cf0139c1497.png)