### PR TITLE
Добавляет слияние и сортировку для media выражений

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -12,6 +12,7 @@ gulp.task('styles', () => {
             require('postcss-import'),
             require('postcss-color-hex-alpha'),
             require('autoprefixer'),
+            require('postcss-sort-media-queries'),
             require('postcss-csso'),
         ]))
         .pipe(gulp.dest('dist/styles'));

--- a/package-lock.json
+++ b/package-lock.json
@@ -7580,6 +7580,44 @@
         "uniq": "^1.0.1"
       }
     },
+    "postcss-sort-media-queries": {
+      "version": "1.4.24",
+      "resolved": "https://registry.npmjs.org/postcss-sort-media-queries/-/postcss-sort-media-queries-1.4.24.tgz",
+      "integrity": "sha512-cuLvzvZKYPmNrBaNK8eo2RUPlvdIsObCJjTgrggkWQ4ByQqD/YR4D0uU6fOJMTmejRYDJunlpRrQ+UwN+dgoEQ==",
+      "dev": true,
+      "requires": {
+        "postcss": "^7.0.27",
+        "sort-css-media-queries": "1.5.0"
+      },
+      "dependencies": {
+        "postcss": {
+          "version": "7.0.28",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.28.tgz",
+          "integrity": "sha512-YU6nVhyWIsVtlNlnAj1fHTsUKW5qxm3KEgzq2Jj6KTEFOTK8QWR12eIDvrlWhiSTK8WIBFTBhOJV4DY6dUuEbw==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
+    },
     "postcss-syntax": {
       "version": "0.36.2",
       "resolved": "https://registry.npmjs.org/postcss-syntax/-/postcss-syntax-0.36.2.tgz",
@@ -9443,6 +9481,12 @@
           }
         }
       }
+    },
+    "sort-css-media-queries": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/sort-css-media-queries/-/sort-css-media-queries-1.5.0.tgz",
+      "integrity": "sha512-QofNE7CEVH1AKdhS7L9IPbV9UtyQYNXyw++8lC+xG6iOLlpzsmncZRiKbihTAESvZ8wOhwnPoesHbMrehrQyyw==",
+      "dev": true
     },
     "source-map": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "postcss-color-hex-alpha": "^6.0.0",
     "postcss-csso": "^4.0.0",
     "postcss-import": "^12.0.1",
+    "postcss-sort-media-queries": "^1.4.24",
     "pretty-data": "^0.40.0",
     "remark-cli": "^8.0.0",
     "remark-frontmatter": "^2.0.0",

--- a/src/styles/blocks/articles.css
+++ b/src/styles/blocks/articles.css
@@ -18,7 +18,7 @@
 @media (min-width: 1024px) {
     .articles__item {
         min-height: 107px;
-        padding: 16px 0;
+        padding-top: 16px;
     }
 }
 
@@ -92,6 +92,7 @@
     .articles__item--featured {
         grid-row-start: 1;
         grid-row-end: 3;
+        padding: 16px 0;
         box-shadow: 0 0 0 1px var(--color-grey-dark);
         z-index: 1;
     }

--- a/src/styles/blocks/navigation.css
+++ b/src/styles/blocks/navigation.css
@@ -285,7 +285,7 @@
 }
 
 @media (min-width: 1440px) {
-    .page__navigation--inner .navigation__item {
+    .page__navigation--inner .navigation__item:not(:last-child) {
         margin-right: 20px;
     }
 }


### PR DESCRIPTION
https://github.com/web-standards-ru/web-standards.ru/issues/53

Отказался от csso (forceMediaMerge), потому что MQ надо не только мержить, но  и правильно сортировать(mobile first). Csso не умеет сортировку делать, а только слияние ломает вёрстку тем что значения меньшей ширины идут после больших.

Поэтому пришлось использовать отдельный плагин postcss https://github.com/yunusga/postcss-sort-media-queries

Обратил внимание что postcss-плагин и csso не смогли смержить `@media (hover: hover)` не большая проблема их всего две штуки.

Из-за смены порядка MQ для _articles_ и _navigation_ пришлось поправить падинги, потому что стили для элемента оказались ниже стилей для модификатора.