### PR TITLE
Позволяет выделять весь код в статьях

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -12,7 +12,10 @@ module.exports = function(config) {
     const markdownItAnchor = require('./src/helpers/markdownItAnchor.js');
 
     config.setLibrary('md', markdownIt({
-        html: true
+        html: true,
+        highlight: function (str, lang) {
+            return `<pre><code tabindex="0"${lang ? ` class="language-${lang}"` : ''}>${md.utils.escapeHtml(str)}</code></pre>`;
+        },
     }).use(markdownItAnchor, {
         permalink: true,
         permalinkClass: 'article__heading-anchor',

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -11,7 +11,7 @@ module.exports = function(config) {
     const markdownIt = require('markdown-it');
     const markdownItAnchor = require('./src/helpers/markdownItAnchor.js');
 
-    config.setLibrary('md', markdownIt({
+    const md = require('markdown-it')({
         html: true,
         highlight: function (str, lang) {
             return `<pre><code tabindex="0"${lang ? ` class="language-${lang}"` : ''}>${md.utils.escapeHtml(str)}</code></pre>`;
@@ -25,7 +25,8 @@ module.exports = function(config) {
             'aria-label': 'Этот заголовок',
         }),
         slugify: () => 'section',
-    }));
+    });
+    config.setLibrary('md', md);
 
     config.addCollection('tagList', (collection) => {
         const set = new Set();

--- a/.eleventy.js
+++ b/.eleventy.js
@@ -8,7 +8,6 @@ module.exports = function(config) {
 
     // Markdown Options
 
-    const markdownIt = require('markdown-it');
     const markdownItAnchor = require('./src/helpers/markdownItAnchor.js');
 
     const md = require('markdown-it')({

--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -311,6 +311,17 @@
     overflow-x: auto;
     scrollbar-width: thin;
     scrollbar-color: var(--color-green-darker) transparent;
+    user-select: all;
+}
+
+.content pre code:focus {
+    animation: code-select 100ms step-end forwards;
+}
+
+@keyframes code-select {
+    to {
+        user-select: text;
+    }
 }
 
 @media (min-width: 1240px) {


### PR DESCRIPTION
Fixes #56 

Disclaimer: У меня совсем мало опыта со генераторами статических сайтов, с Eleventy познакомился только у вас в проекте. Поэтому я могу неправильно понимать какие-то концепции его использования.

Столкнувшись с необходимостью добавить атрибут `tabindex` к тегу `code`, я пробовал `config.addFilter('markdown' ...`, однако никакого эффекта он не вызывал. Насколько я понял, этот фильтр сейчас вообще не используется.

В документации увидел способ подключения `markdown-it`, которым и воспользовался.

В контексте добавления атрибута именно к тегу `code`, подумал, что легче будет воспользоваться колбэком `highlight`.

На текущем этапе все работает, однако хочу убедиться, что строкой `config.setLibrary('md', md);` я ничего не должен был сломать. Со своей стороны я проверил несколько статей параграф за параграфом и никаких проблем не заметил.

Вот что по моему мнению осталось обсудить и в случае чего, сделать:
- [x] Подтвердить, что установкой библиотеки для .md я ничего не сломал
- [x] Явно добавить `markdown-it` в зависимости в `package.json` **(не требуется)**
- [ ]  Из-за добавления `tabindex` на `code`, он стал интерактивным элементом и на нем появился outline. Нужно решить, нужен ли он. А еще вот думаю - не влияет ли как то это на доступность, не нужно ли как-то отметить для скрин ридеров, почему вообще фокус на элементе появился?