### PR TITLE
Расставляет точки в 'alt'

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -180,6 +180,18 @@ module.exports = function(config) {
         return content;
     });
 
+    config.addTransform('addingPointsInAlt', (content, outputPath) => {
+        if (outputPath && outputPath.endsWith('.html')) {
+            let img = /\<img(.*?)alt\=\"(.*?)\"/ig;
+            return content.replace(img, (match, p1, p2) => {
+                if (p2 && !p2.endsWith('.')) {
+                    return match.replace(p2, p2 + '.');
+                }
+                return match;
+            });
+        }
+    });
+
     // Теги
 
     config.addNunjucksTag('blob', (nunjucksEngine) => {


### PR DESCRIPTION
Согласно [CONTRIBUTING](https://github.com/web-standards-ru/web-standards.ru/blob/master/CONTRIBUTING.md#%D1%80%D0%B0%D0%B1%D0%BE%D1%82%D0%B0-%D1%81-%D0%B8%D0%B7%D0%BE%D0%B1%D1%80%D0%B0%D0%B6%D0%B5%D0%BD%D0%B8%D1%8F%D0%BC%D0%B8) сделал трансформацию, которая расставляет во всех `**.html` в конце всех не пустых `alt` точки.
Так же есть статьи в которых отсутствует как `alt` так и `figcaption`. Расстановку альтов можно выделить в отдельную задачу (по-моему она уже была в старом репозитории).