### PR TITLE
Подчёркивает все ссылки в статье

### DIFF
--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -87,16 +87,6 @@
 
 /* Links */
 
-.content a {
-    text-decoration: none;
-}
-
-@media (min-width: 1240px) {
-    .content a {
-        text-decoration: underline;
-    }
-}
-
 .content a:link {
     color: var(--color-blue-darker);
     transition: color 0.2s linear;


### PR DESCRIPTION
Из-за того, что мы сделали контрастный цвет посещённых ссылок, они слились с текстом. К тому же у нас все ссылки потихоньку возвращаются в исходное состояние.

_Было:_

![2](https://user-images.githubusercontent.com/48956742/81319147-708f2400-90b9-11ea-8745-0f3fe856011f.png)

_Стало:_

![3](https://user-images.githubusercontent.com/48956742/81319151-71c05100-90b9-11ea-9737-5a6d101fac48.png)
