### PR TITLE
Делает aria-label в меню переключаемым

### DIFF
--- a/src/scripts/scripts.js
+++ b/src/scripts/scripts.js
@@ -15,6 +15,12 @@
         const isMenuHidden = isMenuHiddenCheck();
         navigationButton.setAttribute('aria-expanded', !isMenuHidden);
 
+        if (isMenuHidden) {
+            navigationButton.setAttribute('aria-label', 'Открыть меню');
+        } else {
+            navigationButton.setAttribute('aria-label', 'Закрыть меню');
+        }
+
         setTimeout(() => pageBody.classList.toggle('page__body--active'), 200);
     };
 


### PR DESCRIPTION
Сейчас на кнопке меню `aria-label="Открыть меню"` вне зависимости от его состояния. Сделал так, чтобы при закрытом меню было `Открыть меню`, а при открытом `Закрыть меню`.