### PR TITLE
Исправляет отображение карточек related статей #85

### DIFF
--- a/src/includes/article-card.njk
+++ b/src/includes/article-card.njk
@@ -20,7 +20,7 @@
         </a>
     </h3>
 
-    {% if featured %}
+    {% if featured and articleCardVariant !== 'related' %}
         <p class="article-card__preview">
             {{ article.data.preview }}
         </p>
@@ -48,7 +48,7 @@
             {{ person.name }}
         </span>
 
-        {% if not featured %}
+        {% if not featured or articleCardVariant == 'related' %}
             <div class="
                 article-card__avatar
                 article-card__avatar{{ articleType }}
@@ -64,7 +64,7 @@
         {% endif %}
     {% endfor %}
 
-    {% if featured %}
+    {% if featured and articleCardVariant !== 'related' %}
         {% if article.data.hero.src %}
             {% set featuredImg = [article.url, article.data.hero.src] | join %}
         {% else %}

--- a/src/layouts/article.njk
+++ b/src/layouts/article.njk
@@ -120,6 +120,7 @@ layout: page.njk
         <h2 class="related-articles__title">Ещё</h2>
 
         {% set articleType %}{{ '--related' }}{% endset %}
+        {% set articleCardVariant = 'related' %}
 
         <ul class="articles articles{{ articleType }}">
             {%- for article in collections.article | reverse | filterCurrentPage(page) | limit(3) -%}


### PR DESCRIPTION
Fixes #85 
Что сделал: перед выводом карточек статей в блоке "Ещё" создал переменную `articleCardVariant` со значением `related`.

В `article-card` собственно проверяю на это значение, логика с featured выполняется только если этого значения нет.

Не знаю насколько это костыльно и вообще правильно, но беглая проверка не выявила проблем