### PR TITLE
Исправляет вывод обложек статей

### DIFF
--- a/src/layouts/article.njk
+++ b/src/layouts/article.njk
@@ -36,8 +36,14 @@ layout: page.njk
                 </div>
             </div>
             {% if hero %}
-            <div class="article__hero">
-                <img src="{{ hero.src }}" class="article__hero-image" alt="{% if hero.alt %}{{ hero.alt }}{% endif %}" itemprop="image">
+            <div class="article__hero"
+                {% if hero.contain %}
+                    style="background-color: {{ hero.contain }};"
+                {% endif %}>
+                <img src="{{ hero.src }}" class="article__hero-image" alt="{% if hero.alt %}{{ hero.alt }}{% endif %}" itemprop="image"
+                {% if hero.contain %}
+                    style="object-fit: contain;"
+                {% endif%}>
             </div>
             {% endif %}
         </div>


### PR DESCRIPTION
Fixes #45 
Предлагаю такое решение: в зависимости от наличия в мете статьи `hero.contain` object-fit картинки меняется на `contain`, а блоку с картинкой добавляется заливка с цветом указанном в `hero.contain`.
Мне не очень нравится, что стили прописываются в html. Возможно есть способ как добавить это сразу в css?