### PR TITLE
Исправляет налезающее видео на текст контента

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -187,7 +187,7 @@ module.exports = function(config) {
                 return `
                     <div class="video">
                         <a class="video__link" href="https://youtu.be/${p1}">
-                            <img class="video__media" src="https://img.youtube.com/vi/${p1}/hqdefault.jpg" alt="">
+                            <img class="video__media" src="https://img.youtube.com/vi/${p1}/maxresdefault.jpg" alt="">
                         </a>
                         <button class="video__button" type="button" aria-label="Запустить видео">
                             <svg width="68" height="48" viewBox="0 0 68 48"><path class="video__button-shape" d="M66.52,7.74c-0.78-2.93-2.49-5.41-5.42-6.19C55.79,.13,34,0,34,0S12.21,.13,6.9,1.55 C3.97,2.33,2.27,4.81,1.48,7.74C0.06,13.05,0,24,0,24s0.06,10.95,1.48,16.26c0.78,2.93,2.49,5.41,5.42,6.19 C12.21,47.87,34,48,34,48s21.79-0.13,27.1-1.55c2.93-0.78,4.64-3.26,5.42-6.19C67.94,34.95,68,24,68,24S67.94,13.05,66.52,7.74z"></path><path class="video__button-icon" d="M 45,24 27,14 27,34"></path></svg>

--- a/src/styles/blocks/video.css
+++ b/src/styles/blocks/video.css
@@ -17,12 +17,13 @@
     height: 100%;
 }
 
-.video__media {
+.video .video__media {
     position: absolute;
     top: 0;
     left: 0;
     width: 100%;
     height: 100%;
+    margin: 0;
     border: none;
 }
 


### PR DESCRIPTION
Fixes #99
Поправил стили для картинки, которая грузится с ютуба. Изначальные стили перебивались стилями из блока `content.css`. Так же заметил что картинки, которые дает ютуб, имели черные полосы сверху и снизу, что приводило к нарушению пропорций самой картинки в блоке с соотношением сторон 16:9. 

Провел небольшой анализ и вот что получилось.
Картинки без черных полос есть в обычном разрешении `mqdefault` и в высоком `maxresdefault `. Визуальная разница между ними заметна, вот пара примеров:
mqdefault:
![image](https://user-images.githubusercontent.com/28845333/83952662-d0a4f180-a842-11ea-930a-edc021307995.png)
![image](https://user-images.githubusercontent.com/28845333/83952667-dbf81d00-a842-11ea-9896-cbad4d8750fc.png)

maxresdefault:
![image](https://user-images.githubusercontent.com/28845333/83952681-03e78080-a843-11ea-9a1c-3ec6491aca29.png)
![image](https://user-images.githubusercontent.com/28845333/83952690-12ce3300-a843-11ea-8a6d-a69f9b9cc4cf.png)

Так же есть проблема с `maxresdefault` в статье [Почему у нас нет селектора по родителю]( https://web-standards.ru/articles/parent-selector/). Там ютуб ничего не отдает:
![image](https://user-images.githubusercontent.com/28845333/83952733-6771ae00-a843-11ea-9356-d696821f795e.png)

Еще вот посчитал разницу в весе картинок в статьях где есть видео:
| Статья | mqdefault | maxresdefault |
| --- | --- | --- |
| [Инклюзивные компоненты: меню и кнопки меню](https://web-standards.ru/articles/menu-buttons/) | 11,9 kB | 57,3 kB |
| [Не проверив HTML5-кода, не суйся в воду — с Майком™ Смитом](https://web-standards.ru/articles/check-it-before-you-wreck-it/) | 9,6 kB | 77,6 kB |
| [Почему у нас нет селектора по родителю](https://web-standards.ru/articles/parent-selector/) | 8,1 kB | none |
| [Полезные правила доступности, которые останутся в памяти](https://web-standards.ru/articles/pragmatic-a11y-rules/) | 4,4 kB | 32,8 kB |
| [Сколько стоит JavaScript?](https://web-standards.ru/articles/the-cost-of-javascript/) | 13,3 kB | 93,8 kB |

Так вот вопрос, какую картинку лучше грузить?
На мой взгляд, лучше - maxresdefault, но удручает, что в одной статье ее просто нет.

