### PR TITLE
Фикс неправильного поведения верстки при смене портретного режима на ландшафтный

### DIFF
--- a/src/styles/blocks/navigation.css
+++ b/src/styles/blocks/navigation.css
@@ -1,9 +1,14 @@
 /* Navigation */
 
+.navigation {
+    position: relative;
+    width: 100%;
+}
+
 /* Logo */
 
 .navigation__logo {
-    position: fixed;
+    position: absolute;
     z-index: -1;
     width: 100%;
     height: 80px;


### PR DESCRIPTION
Попытка починить #113 

Мне показалось безсмыссленным изпользование fixed для logo поэтому его позиционирование изменено на absolute.
А враперу добавлены свойства position: relative и width: 100%, чтобы он всегда сохранял максимальную ширину и не становился больше чем vieport.

Если в fixed был какой-то особый смысл commets pls.