### PR TITLE
Исправление стилей медиа-контента

### DIFF
--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -197,11 +197,8 @@
 
 /* Images */
 
-.content > img,
-.content > video,
-.content figure > img,
-.content figure > video,
-.content a > img {
+.content img,
+.content video {
     display: block;
     max-width: 100%;
     height: auto;
@@ -209,9 +206,9 @@
 }
 
 @media (min-width: 1240px) {
-    .content > img,
-    .content > video {
-        margin: 60px 0 60px auto;
+    .content img,
+    .content video {
+        margin: 60px 0;
     }
 }
 


### PR DESCRIPTION
Сделал стили изображений и видео в статьях менее хрупкими (#155):
- убрал жёсткую привяку к непосредственному родителю;
- обнулил боковые отступы на десктопах.

Поясню про отступы, ибо это решение может быть спорным.
Растягивать небольшие изображения на всю контентную ширину не очень хорошо, будет мыло пиксельное. А прежний стиль `margin: 60px 0 60px auto;` медиа-контент шириной меньшей ширины контентной колонки прибивал к правому краю. При больших медиа оно ещё нормально смотрится, но вот с маленькими в купе с выравниванием текста влево выглядит кособоко: картинка/видео будто вырваны из текста вправо, но не полностью, на выноску не тянет.
В макете для меньших изображений нашёл только вариант, когда они зафлоачены вправо. С флоатом они нормально бы смотрелись, не оторваными.
Если же в нашем случае оба боковых отступа обнулить, картинки прижмутся влево и пристроются к чёткому левому краю текста, что выглядит более органично.
Но возможно я что-то не знаю и у этого левого `auto` была какая-то значимая причина. Так что правку отступа легко можно откатить обратно. А вот первый пункт _хрупкости_ довольно важен, так как изображения и видео могут быть внутри параграфа, цитаты, figure, и может ещё чего-то.

Правки проверил почти на всех статьях на десктопе и мобильном — всё аккуратно вписывается в столбец текста.

---
Resolves #155