### PR TITLE
Чистка недочищенного

### DIFF
--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -205,13 +205,6 @@
     margin: 16px 0 8px;
 }
 
-@media (min-width: 1240px) {
-    .content img,
-    .content video {
-        margin: 60px 0;
-    }
-}
-
 /* Quotes */
 
 .content blockquote {


### PR DESCRIPTION
В #156 надо было бы ещё и это медиа-выражение удалить.
Из-за него на десктопе подписи внутри `figure` отталкиваются на 60px.