### PR TITLE
Убираем предыдущий хэш из ссылки перед копированием

### DIFF
--- a/src/scripts/modules/copy-link.js
+++ b/src/scripts/modules/copy-link.js
@@ -21,8 +21,9 @@ function setErrorState(tooltip) {
 function handleCopy() {
     const tooltip = this.nextSibling;
     const hash = this.getAttribute('data-href');
+    const url = window.location.href.replace(window.location.hash, '');
 
-    navigator.clipboard.writeText(`${window.location.href}${hash}`)
+    navigator.clipboard.writeText(`${url}${hash}`)
         .then(() => {
             setSuccessState(tooltip);
         })


### PR DESCRIPTION
Фикс #169 
Вырезаем хэш из текущего url.
Кэш должен удаляться безопасно так как всегда начинается с `#`
