### PR TITLE
Фикс карточки статей для маленьких экранов

### DIFF
--- a/src/styles/blocks/article-card.css
+++ b/src/styles/blocks/article-card.css
@@ -11,7 +11,7 @@
     padding: 0 16px;
 }
 
-@media (min-width: 320px) {
+@media (min-width: 460px) {
     .article-card {
         grid-template-areas:
             'picture title title'

--- a/src/styles/blocks/article-card.css
+++ b/src/styles/blocks/article-card.css
@@ -5,9 +5,18 @@
     grid-template-columns: min-content max-content 1fr;
     grid-template-areas:
         'picture title title'
-        'picture date author';
+        'picture date date'
+        'picture author author';
     grid-gap: 14px 16px;
     padding: 0 16px;
+}
+
+@media (min-width: 320px) {
+    .article-card {
+        grid-template-areas:
+            'picture title title'
+            'picture date author';
+    }
 }
 
 @media (min-width: 800px) {


### PR DESCRIPTION
Если ширина экрана меньше 320px то переносим автора на новую строку.
Должно пофиксить #191 

Пример:

![315px](https://user-images.githubusercontent.com/8425363/107607376-7f12f900-6c52-11eb-891a-eec56866eb65.png)
