### PR TITLE
Фикс карточки автора на узком дисплее

### DIFF
--- a/src/styles/blocks/creators.css
+++ b/src/styles/blocks/creators.css
@@ -16,10 +16,16 @@
 }
 
 .creators__author {
-    margin-right: 32px;
+    margin-right: 20px;
     color: var(--color-grey-darker);
     letter-spacing: 0.05em;
     text-transform: uppercase;
+}
+
+@media (min-width: 375px) {
+    .creators__autor {
+        margin-right: 32px;
+    }
 }
 
 @media (min-width: 1240px) {
@@ -83,7 +89,13 @@
 }
 
 .creators__collaborators:not(:last-child) {
-    margin-right: 32px;
+    margin-right: 20px;
+}
+
+@media (min-width: 375px) {
+    .creators__collaborators:not(:last-child) {
+        margin-right: 32px;
+    }
 }
 
 @media (min-width: 1240px) {


### PR DESCRIPTION
Решает #192

Пока сделал по прострому.
Можно добавить `overflow: hidden;` и `text-overflow: ellipsis;` чтобы если имя или фамилия слишком длинная то уходило в точки.