### PR TITLE
Использование `eleventyComputed` для получения данных о людях

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -91,19 +91,6 @@ module.exports = function(config) {
         );
     });
 
-    config.addFilter('filterPeople', (peopleList, filterList) => {
-        return peopleList
-            .filter((person) => {
-                // Иногда filterList это строка, а не массив, поэтому всегда делаем массив
-                const filterListNormalized = [].concat(filterList);
-
-                return filterListNormalized.includes(person.fileSlug);
-            })
-            .map((person) => {
-                return person.data;
-            });
-    });
-
     config.addFilter('addHyphens', (content, maxLength = 0) => {
         if (!content || content.length <= maxLength) {
             return content;

--- a/src/articles/articles.11tydata.js
+++ b/src/articles/articles.11tydata.js
@@ -1,0 +1,28 @@
+function filterPeople(peopleList, filterList) {
+    return peopleList
+        .filter((person) => {
+            // Иногда filterList это строка, а не массив, поэтому всегда делаем массив
+            const filterListNormalized = [].concat(filterList);
+
+            return filterListNormalized.includes(person.fileSlug);
+        })
+        .map((person) => {
+            return person.data;
+        });
+}
+
+module.exports = {
+    eleventyComputed: {
+        authorData: function(data) {
+            return filterPeople(data.collections.people, data.author)
+        },
+
+        translatorsData: function(data) {
+            return filterPeople(data.collections.people, data.translators)
+        },
+
+        editorsData: function(data) {
+            return filterPeople(data.collections.people, data.editors)
+        }
+    }
+}

--- a/src/includes/article-card.njk
+++ b/src/includes/article-card.njk
@@ -34,7 +34,7 @@
         {{ article.date | ruDate }}
     </time>
 
-    {% for person in collections.people | filterPeople(article.data.author) %}
+    {% for person in article.data.authorData %}
         {% if person.photo %}
             {% set personPhoto = [article.data.author, '/photo.jpg'] | join %}
         {% else %}

--- a/src/layouts/article.njk
+++ b/src/layouts/article.njk
@@ -47,7 +47,7 @@ layout: page.njk
             {% endif %}
         </div>
         <div class="article__creators creators">
-            {% for person in collections.people | filterPeople(author) %}
+            {% for person in authorData %}
                 {% if person.photo %}
                     {% set personPhoto = [author, '/photo.jpg'] | join %}
                 {% else %}
@@ -82,7 +82,7 @@ layout: page.njk
             {% if translators %}
                 <p class="creators__collaborators">
                     <span class="creators__collaborators-heading">Перевод</span>
-                    {%- for translator in collections.people | filterPeople(translators) -%}
+                    {%- for translator in translatorsData -%}
                         {% if translator.url %}
                             <a class="creators__collaborators-link"
                                 href="{{ translator.url }}"
@@ -101,7 +101,7 @@ layout: page.njk
             {% if editors %}
                 <p class="creators__collaborators">
                     <span class="creators__collaborators-heading">Редактура</span>
-                    {%- for editor in collections.people | filterPeople(editors) -%}
+                    {%- for editor in editorsData -%}
                         {% if editor.url %}
                             <a class="creators__collaborators-link"
                                 href="{{ editor.url }}"


### PR DESCRIPTION
Сейчас для извлечения данных о людях в статьях используется nunjucks-фильтр `filterPeople `, например:
```nunjucks
{%- for translator in collections.people | filterPeople(translators) -%}
```
Это все равно что делать запросы в базу данных из шаблонизатора.

Предлагаю использовать поле `eleventyComputed` в data-файлах для получения этих данных. Таким образом, мы переносим логику в слой данных, где она и должна быть.

В некоторых своих проектах я перезатираю оригинальное поле computed-полем, то есть вместо, например, поля `author` с id автора будет подставляться объект с данными автора. Здесь заведены отдельные поля, например, `authorData` для явности.

Другими словами, такое поведение имитирует join'ы в SQL или _reference populate_ в MongoDB. 