### PR TITLE
Поправил отрывающуюся стрелку у тултипа

### DIFF
--- a/src/styles/blocks/tooltip.css
+++ b/src/styles/blocks/tooltip.css
@@ -48,14 +48,14 @@
 }
 
 .tooltip__label::after {
-    --tooltip-tail-width: 26px;
-    --tooltip-tail-height: 11px;
-    position: absolute;
-    top: calc(100% - 1px);
-    left: calc(50% - var(--tooltip-tail-width) / 2);
     content: '';
-    width: var(--tooltip-tail-width);
-    height: var(--tooltip-tail-height);
+    position: absolute;
+    top: 100%;
+    right: 0;
+    left: 0;
+    width: 26px;
+    height: 11px;
+    margin: -1px auto 0;
     background-color: inherit;
     clip-path: polygon(0 0, 100% 0, 50% 100%);
 }

--- a/src/styles/blocks/tooltip.css
+++ b/src/styles/blocks/tooltip.css
@@ -48,10 +48,10 @@
 }
 
 .tooltip__label::after {
-    --tooltip-tail-width: 24px;
-    --tooltip-tail-height: 10px;
+    --tooltip-tail-width: 26px;
+    --tooltip-tail-height: 11px;
     position: absolute;
-    top: 100%;
+    top: calc(100% - 1px);
     left: calc(50% - var(--tooltip-tail-width) / 2);
     content: '';
     width: var(--tooltip-tail-width);


### PR DESCRIPTION
На тачевых девайсах с произвольным зумом мог отрываться уголок от тултипа
![screen_20210321_18:04:07](https://user-images.githubusercontent.com/4380238/111909836-e1d88b00-8a6f-11eb-98f2-ab2f49b018a6.png)
