### PR TITLE
Определение основного layout в data-файле

### DIFF
--- a/src/articles/a-content-slider/index.md
+++ b/src/articles/a-content-slider/index.md
@@ -8,7 +8,6 @@ source:
 translators: tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/a-todo-list/index.md
+++ b/src/articles/a-todo-list/index.md
@@ -9,7 +9,6 @@ translators:
     - tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/a11y-and-law/index.md
+++ b/src/articles/a11y-and-law/index.md
@@ -4,7 +4,6 @@ date: 2019-11-04
 author: tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - a11y

--- a/src/articles/a11y-poll-2019/index.md
+++ b/src/articles/a11y-poll-2019/index.md
@@ -4,7 +4,6 @@ date: 2019-11-14
 author: tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - a11y

--- a/src/articles/a11y-testing-in-it-academy/index.md
+++ b/src/articles/a11y-testing-in-it-academy/index.md
@@ -9,7 +9,6 @@ translators:
     - hanna-ostroverkha
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - a11y

--- a/src/articles/a11y-users-interview/index.md
+++ b/src/articles/a11y-users-interview/index.md
@@ -4,7 +4,6 @@ date: 2018-02-19
 author: evgeniy-karavaev
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - a11y

--- a/src/articles/accessible-svg-icons/index.md
+++ b/src/articles/accessible-svg-icons/index.md
@@ -9,7 +9,6 @@ translators:
     - tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/accessible-to-some/index.md
+++ b/src/articles/accessible-to-some/index.md
@@ -10,7 +10,6 @@ translators:
 editors:
     - olga-aleksashenko
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - a11y

--- a/src/articles/aria-live-regions/index.md
+++ b/src/articles/aria-live-regions/index.md
@@ -4,7 +4,6 @@ date: 2019-03-12
 author: tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/articles.11tydata.js
+++ b/src/articles/articles.11tydata.js
@@ -12,6 +12,8 @@ function filterPeople(peopleList, filterList) {
 }
 
 module.exports = {
+    layout: 'article.njk',
+
     eleventyComputed: {
         authorData: function(data) {
             return filterPeople(data.collections.people, data.author)

--- a/src/articles/avoiding-html5-mistakes/index.md
+++ b/src/articles/avoiding-html5-mistakes/index.md
@@ -7,7 +7,6 @@ source:
     url: 'https://html5doctor.com/avoiding-common-html5-mistakes/'
 translators:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/big-screens/index.md
+++ b/src/articles/big-screens/index.md
@@ -11,7 +11,6 @@ editors:
     - yuliya-bukhvalova
     - vadim-makeev
     - olga-aleksashenko
-layout: article.njk
 tags:
     - article
     - design

--- a/src/articles/boring-bits-of-css/index.md
+++ b/src/articles/boring-bits-of-css/index.md
@@ -9,7 +9,6 @@ translators:
     - vlad-andersen
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/box-sizing/index.md
+++ b/src/articles/box-sizing/index.md
@@ -9,7 +9,6 @@ translators:
     - sergey-smolnikov
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/broken-promise-web-comps/index.md
+++ b/src/articles/broken-promise-web-comps/index.md
@@ -9,7 +9,6 @@ translators:
     - vladislav-pocheptsov
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/can-i-include/index.md
+++ b/src/articles/can-i-include/index.md
@@ -6,7 +6,6 @@ author:
 translators:
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/cargo-cult-css/index.md
+++ b/src/articles/cargo-cult-css/index.md
@@ -10,7 +10,6 @@ translators:
 editors:
     - vadim-makeev
     - olga-aleksashenko
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/check-it-before-you-wreck-it/index.md
+++ b/src/articles/check-it-before-you-wreck-it/index.md
@@ -11,7 +11,6 @@ translators:
 editors:
     - vadim-makeev
     - olga-aleksashenko
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/cite-blockquote-reloaded/index.md
+++ b/src/articles/cite-blockquote-reloaded/index.md
@@ -11,7 +11,6 @@ editors:
     - yuliya-bukhvalova
     - vadim-makeev
     - olga-aleksashenko
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/clipboard-api/index.md
+++ b/src/articles/clipboard-api/index.md
@@ -5,7 +5,6 @@ author: pavel-mineev
 editors:
     - vadim-makeev
     - nikita-dubko
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/coder-vs-designer/index.md
+++ b/src/articles/coder-vs-designer/index.md
@@ -4,7 +4,6 @@ date: 2010-06-22
 author: olga-aleksashenko
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - design

--- a/src/articles/collapsible-sections/index.md
+++ b/src/articles/collapsible-sections/index.md
@@ -9,7 +9,6 @@ translators:
     - tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/complex-css-illustrations/index.md
+++ b/src/articles/complex-css-illustrations/index.md
@@ -10,7 +10,6 @@ translators:
 editors:
     - olga-aleksashenko
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/contenteditable/index.md
+++ b/src/articles/contenteditable/index.md
@@ -9,7 +9,6 @@ translators:
     - anton-nemtsev
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/critical-and-progressive-css/index.md
+++ b/src/articles/critical-and-progressive-css/index.md
@@ -5,7 +5,6 @@ author: daniil-onoshko
 editors:
     - irina-pitaeva
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/critical-css/index.md
+++ b/src/articles/critical-css/index.md
@@ -9,7 +9,6 @@ translators:
     - alena-batickaya
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/cross-browser-rounded-corners/index.md
+++ b/src/articles/cross-browser-rounded-corners/index.md
@@ -4,7 +4,6 @@ date: 2010-06-28
 author: lev-solntsev
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/css-architecture/index.md
+++ b/src/articles/css-architecture/index.md
@@ -9,7 +9,6 @@ translators:
     - vadim-makeev
 editors:
     - olga-aleksashenko
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/css-image-replacement/index.md
+++ b/src/articles/css-image-replacement/index.md
@@ -9,7 +9,6 @@ translators:
     - maxim-usachev
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/css-new-kind-of-javascript/index.md
+++ b/src/articles/css-new-kind-of-javascript/index.md
@@ -10,7 +10,6 @@ translators:
 editors:
     - olga-aleksashenko
     - andrey-melikhov
-layout: article.njk
 tags:
     - article
     - satire

--- a/src/articles/css-nuances/index.md
+++ b/src/articles/css-nuances/index.md
@@ -4,7 +4,6 @@ date: 2011-04-21
 author: lev-solntsev
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/css-techniques-p1-tables/index.md
+++ b/src/articles/css-techniques-p1-tables/index.md
@@ -4,7 +4,6 @@ date: 2013-06-27
 author: lev-solntsev
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/css-techniques-p2-alternate/index.md
+++ b/src/articles/css-techniques-p2-alternate/index.md
@@ -4,7 +4,6 @@ date: 2013-06-28
 author: lev-solntsev
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/css-vs-js-same-story/index.md
+++ b/src/articles/css-vs-js-same-story/index.md
@@ -7,7 +7,6 @@ source:
     url: 'https://twitter.com/tobie/status/1083316137826365442'
 translators:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/css-vs-js/index.md
+++ b/src/articles/css-vs-js/index.md
@@ -9,7 +9,6 @@ translators:
     - alena-batickaya
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/desktop-app/index.md
+++ b/src/articles/desktop-app/index.md
@@ -9,7 +9,6 @@ translators:
     - alena-batickaya
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/details-summary-elements/index.md
+++ b/src/articles/details-summary-elements/index.md
@@ -7,7 +7,6 @@ source:
     url: 'https://html5doctor.com/the-details-and-summary-elements/'
 translators:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/docker-unboxing-1/index.md
+++ b/src/articles/docker-unboxing-1/index.md
@@ -4,7 +4,6 @@ date: 2021-02-08
 author: igor-korovchenko
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/docker-unboxing-2/index.md
+++ b/src/articles/docker-unboxing-2/index.md
@@ -4,7 +4,6 @@ date: 2021-02-09
 author: igor-korovchenko
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/docker-unboxing-3/index.md
+++ b/src/articles/docker-unboxing-3/index.md
@@ -4,7 +4,6 @@ date: 2021-02-10
 author: igor-korovchenko
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/dont-like-ie6-really/index.md
+++ b/src/articles/dont-like-ie6-really/index.md
@@ -7,7 +7,6 @@ source:
     url: 'http://remy.tumblr.com/post/8334086394/what-do-you-mean-you-dont-like-ie6-really'
 translators:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
 preview: 'Если поддержка IE6 является частью вашей работы или включена в договор — значит так оно и есть, такова профессия, и в этих сложностях её смысл.'

--- a/src/articles/driver-or-mechanic/index.md
+++ b/src/articles/driver-or-mechanic/index.md
@@ -9,7 +9,6 @@ translators:
     - vadim-makeev
 editors:
     - olga-aleksashenko
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/enhancing-comment-form/index.md
+++ b/src/articles/enhancing-comment-form/index.md
@@ -11,7 +11,6 @@ editors:
     - vadim-makeev
     - yuliya-bukhvalova
     - alexey-simonenko
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/episode-252/index.md
+++ b/src/articles/episode-252/index.md
@@ -3,7 +3,6 @@ title: 'Опрос MDN, Igalia, npm 7, React vs WordPress, уже Webpack 5, 
 date: 2020-10-28
 author:
     - nikita-dubko
-layout: article.njk
 tags:
     - article
     - podcast

--- a/src/articles/es-modules-cartoon-dive/index.md
+++ b/src/articles/es-modules-cartoon-dive/index.md
@@ -9,7 +9,6 @@ translators:
     - artur-khrabrov
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/fetch-vs-axios/index.md
+++ b/src/articles/fetch-vs-axios/index.md
@@ -9,7 +9,6 @@ translators:
     - artur-khrabrov
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/figure-figcaption/index.md
+++ b/src/articles/figure-figcaption/index.md
@@ -9,7 +9,6 @@ translators:
     - ekaterina-mordvina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/fixing-lists/index.md
+++ b/src/articles/fixing-lists/index.md
@@ -9,7 +9,6 @@ translators:
     - tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/focus-and-inert/index.md
+++ b/src/articles/focus-and-inert/index.md
@@ -12,7 +12,6 @@ editors:
     - nikita-dubko
     - tatiana-fokina
     - vasiliy-dudin
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/front-end-interview-handbook/index.md
+++ b/src/articles/front-end-interview-handbook/index.md
@@ -9,7 +9,6 @@ translators:
     - alena-batickaya
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/front-end-performance/index.md
+++ b/src/articles/front-end-performance/index.md
@@ -10,7 +10,6 @@ translators:
 editors:
     - vadim-makeev
     - olga-aleksashenko
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/function-decorators/index.md
+++ b/src/articles/function-decorators/index.md
@@ -9,7 +9,6 @@ translators:
     - vladislav-pocheptsov
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/heading-levels/index.md
+++ b/src/articles/heading-levels/index.md
@@ -9,7 +9,6 @@ translators:
     - tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/hello-blink/index.md
+++ b/src/articles/hello-blink/index.md
@@ -9,7 +9,6 @@ translators:
     - anton-nemtsev
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - performance

--- a/src/articles/i-b-em-strong-elements/index.md
+++ b/src/articles/i-b-em-strong-elements/index.md
@@ -9,7 +9,6 @@ translators:
     - vadim-makeev
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/inherit-initial-unset-revert/index.md
+++ b/src/articles/inherit-initial-unset-revert/index.md
@@ -10,7 +10,6 @@ translators:
 editors:
     - vadim-makeev
     - olga-aleksashenko
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/introduction-to-variable-fonts/index.md
+++ b/src/articles/introduction-to-variable-fonts/index.md
@@ -9,7 +9,6 @@ translators:
     - roma-zvarich
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - typography

--- a/src/articles/jquery-now-what/index.md
+++ b/src/articles/jquery-now-what/index.md
@@ -10,7 +10,6 @@ translators:
 editors:
     - vadim-makeev
     - olga-aleksashenko
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/just-use-focus/index.md
+++ b/src/articles/just-use-focus/index.md
@@ -9,7 +9,6 @@ translators:
     - tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/linear-gradient-keywords/index.md
+++ b/src/articles/linear-gradient-keywords/index.md
@@ -9,7 +9,6 @@ translators:
     - vlad-andersen
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/logical-css-props/index.md
+++ b/src/articles/logical-css-props/index.md
@@ -9,7 +9,6 @@ translators:
     - alena-batickaya
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/manifest-what-why/index.md
+++ b/src/articles/manifest-what-why/index.md
@@ -9,7 +9,6 @@ translators:
     - anna-kukhareva
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/menu-buttons/index.md
+++ b/src/articles/menu-buttons/index.md
@@ -9,7 +9,6 @@ translators:
     - tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/mobile-a11y/index.md
+++ b/src/articles/mobile-a11y/index.md
@@ -10,7 +10,6 @@ translators:
 editors:
     - natalya-ryzhova
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/multiline-css/index.md
+++ b/src/articles/multiline-css/index.md
@@ -4,7 +4,6 @@ date: 2010-12-13
 author: vyacheslav-olianchuk
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/multiple-routes-webpack/index.md
+++ b/src/articles/multiple-routes-webpack/index.md
@@ -9,7 +9,6 @@ translators:
     - artur-khrabrov
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/new-in-js2019/index.md
+++ b/src/articles/new-in-js2019/index.md
@@ -9,7 +9,6 @@ translators:
     - alena-batickaya
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/nth-child/index.md
+++ b/src/articles/nth-child/index.md
@@ -7,7 +7,6 @@ source:
     url: 'http://css-tricks.com/5452-how-nth-child-works/'
 translators:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/parent-selector/index.md
+++ b/src/articles/parent-selector/index.md
@@ -7,7 +7,6 @@ source:
     url: 'http://snook.ca/archives/html_and_css/css-parent-selectors/'
 translators:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/path-of-tutor/index.md
+++ b/src/articles/path-of-tutor/index.md
@@ -4,7 +4,6 @@ date: 2016-06-30
 author: maxim-usachev
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
 preview: 'Если звезды фронтенда зажигаются, значит, кто-то их зажигает? Кто? Приоткрываем завесу тайны над темой наставничества в вебе.'

--- a/src/articles/pe-makes-me-sad/index.md
+++ b/src/articles/pe-makes-me-sad/index.md
@@ -7,7 +7,6 @@ source:
     url: 'https://web.archive.org/web/20191023105142/https://heydonworks.com/article/progressive-enhancement-makes-me-sad/'
 translators:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - satire

--- a/src/articles/performance-metrics/index.md
+++ b/src/articles/performance-metrics/index.md
@@ -4,7 +4,6 @@ date: 2017-11-15
 author: artem-denysov
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/pointless-semantic/index.md
+++ b/src/articles/pointless-semantic/index.md
@@ -9,7 +9,6 @@ translators:
     - vlad-andersen
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/position-sticky/index.md
+++ b/src/articles/position-sticky/index.md
@@ -9,7 +9,6 @@ translators:
     - alena-batickaya
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/pragmatic-a11y-rules/index.md
+++ b/src/articles/pragmatic-a11y-rules/index.md
@@ -9,7 +9,6 @@ translators:
     - tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/prefix-or-posthack/index.md
+++ b/src/articles/prefix-or-posthack/index.md
@@ -7,7 +7,6 @@ source:
     url: 'http://www.alistapart.com/articles/prefix-or-posthack/'
 translators:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/print-style-sheets/index.md
+++ b/src/articles/print-style-sheets/index.md
@@ -9,7 +9,6 @@ translators:
     - nikita-dubko
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/promise-burger-party/index.md
+++ b/src/articles/promise-burger-party/index.md
@@ -9,7 +9,6 @@ translators:
     - vladislav-pocheptsov
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/promises-explained/index.md
+++ b/src/articles/promises-explained/index.md
@@ -10,7 +10,6 @@ translators:
     - artur-khrabrov
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/puppeteer-crawl-to-markdown/index.md
+++ b/src/articles/puppeteer-crawl-to-markdown/index.md
@@ -9,7 +9,6 @@ translators:
     - vladislav-ermolin
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/push-front-back/index.md
+++ b/src/articles/push-front-back/index.md
@@ -9,7 +9,6 @@ translators:
     - vladislav-pocheptsov
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/responsive-grid-system/index.md
+++ b/src/articles/responsive-grid-system/index.md
@@ -9,7 +9,6 @@ translators:
     - igor-lesnevskii
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/responsive-typography/index.md
+++ b/src/articles/responsive-typography/index.md
@@ -9,7 +9,6 @@ translators:
     - alexandr-kotomanov
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - fonts

--- a/src/articles/six-things-i-check/index.md
+++ b/src/articles/six-things-i-check/index.md
@@ -10,7 +10,6 @@ translators:
 editors:
     - vadim-makeev
     - nikita-dubko
-layout: article.njk
 tags:
     - article
     - performance

--- a/src/articles/small-hr-elements/index.md
+++ b/src/articles/small-hr-elements/index.md
@@ -7,7 +7,6 @@ source:
     url: 'https://html5doctor.com/small-hr-element/'
 translators:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/speed-up-with-browserslist/index.md
+++ b/src/articles/speed-up-with-browserslist/index.md
@@ -5,7 +5,6 @@ author: daniil-onoshko
 editors:
     - irina-pitaeva
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/state-of-layout/index.md
+++ b/src/articles/state-of-layout/index.md
@@ -4,7 +4,6 @@ date: 2010-08-30
 author: vyacheslav-olianchuk
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/stop-breaking-the-web/index.md
+++ b/src/articles/stop-breaking-the-web/index.md
@@ -9,7 +9,6 @@ translators:
     - olga-aleksashenko
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/svable-server-svg/index.md
+++ b/src/articles/svable-server-svg/index.md
@@ -5,7 +5,6 @@ author: ilya-zayats
 editors:
     - vadim-makeev
     - olga-aleksashenko
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/svg-vertical-text-centering/index.md
+++ b/src/articles/svg-vertical-text-centering/index.md
@@ -9,7 +9,6 @@ translators:
     - anton-nemtsev
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/tabbed-interfaces/index.md
+++ b/src/articles/tabbed-interfaces/index.md
@@ -9,7 +9,6 @@ translators:
     - tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/text-transform-and-copy/index.md
+++ b/src/articles/text-transform-and-copy/index.md
@@ -4,7 +4,6 @@ date: 2019-01-24
 author: igor-shevchenko
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/the-cost-of-javascript/index.md
+++ b/src/articles/the-cost-of-javascript/index.md
@@ -9,7 +9,6 @@ translators:
     - artur-khrabrov
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/theme-switcher/index.md
+++ b/src/articles/theme-switcher/index.md
@@ -9,7 +9,6 @@ translators:
     - tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/todays-js-from-outside/index.md
+++ b/src/articles/todays-js-from-outside/index.md
@@ -10,7 +10,6 @@ translators:
 editors:
     - olga-aleksashenko
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/toggle-buttons/index.md
+++ b/src/articles/toggle-buttons/index.md
@@ -9,7 +9,6 @@ translators:
     - tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/tooltips-toggletips/index.md
+++ b/src/articles/tooltips-toggletips/index.md
@@ -9,7 +9,6 @@ translators:
     - tatiana-fokina
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/top-themes-and-frameworks/index.md
+++ b/src/articles/top-themes-and-frameworks/index.md
@@ -9,7 +9,6 @@ translators:
     - vladislav-pocheptsov
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/translate-attribute/index.md
+++ b/src/articles/translate-attribute/index.md
@@ -9,7 +9,6 @@ translators:
     - vlad-andersen
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/value-of-meaning/index.md
+++ b/src/articles/value-of-meaning/index.md
@@ -9,7 +9,6 @@ translators:
     - vlad-andersen
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/vanishing-entry-points/index.md
+++ b/src/articles/vanishing-entry-points/index.md
@@ -9,7 +9,6 @@ translators:
     - alena-batickaya
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - html

--- a/src/articles/vertical-align/index.md
+++ b/src/articles/vertical-align/index.md
@@ -9,7 +9,6 @@ translators:
     - andrey-motoshin
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/wcag3-changes/index.md
+++ b/src/articles/wcag3-changes/index.md
@@ -6,7 +6,6 @@ editors:
     - vadim-makeev
     - vasiliy-dudin
     - olga-aleksashenko
-layout: article.njk
 tags:
     - article
     - a11y

--- a/src/articles/web-font-loading-patterns/index.md
+++ b/src/articles/web-font-loading-patterns/index.md
@@ -9,7 +9,6 @@ translators:
     - andrey-alexeev
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - fonts

--- a/src/articles/webp-today/index.md
+++ b/src/articles/webp-today/index.md
@@ -9,7 +9,6 @@ translators:
     - vladislav-ermolin
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - js

--- a/src/articles/what-accessibility-taught-me/index.md
+++ b/src/articles/what-accessibility-taught-me/index.md
@@ -9,7 +9,6 @@ translators:
     - alexandr-malinin
 editors:
     - vadim-makeev
-layout: article.njk
 tags:
     - article
     - a11y

--- a/src/articles/why-sass/index.md
+++ b/src/articles/why-sass/index.md
@@ -11,7 +11,6 @@ editors:
     - yuliya-bukhvalova
     - vadim-makeev
     - olga-aleksashenko
-layout: article.njk
 tags:
     - article
     - css

--- a/src/articles/witch-developer/index.md
+++ b/src/articles/witch-developer/index.md
@@ -9,7 +9,6 @@ translators:
     - vadim-makeev
 editors:
     - olga-aleksashenko
-layout: article.njk
 tags:
     - article
     - satire


### PR DESCRIPTION
Здоровья! 

Так как теперь есть общий data-файл для статей, то можно указать один раз `layout: 'article.njk'`. В случае необходимости в data-секции конкретной статьи можно переопределить поле `layout`, например, `layout: 'promo-article.njk'`