### PR TITLE
Использование `font-stretch: expanded` в дескрипторах `@font-face`

### DIFF
--- a/src/styles/blocks/archive.css
+++ b/src/styles/blocks/archive.css
@@ -8,7 +8,9 @@
 
 .archive__title {
     margin: 49px 0 66px;
-    font: 400 24px 'Dewi Expanded', sans-serif;
+    font-weight: 400;
+    font-size: 24px;
+    font-stretch: expanded;
     letter-spacing: -0.05em;
     text-align: center;
     text-transform: uppercase;
@@ -36,7 +38,9 @@
     display: inline-block;
     margin-bottom: 16px;
     margin-left: 16px;
-    font: 700 16px 'Dewi Expanded', sans-serif;
+    font-weight: 700;
+    font-size: 16px;
+    font-stretch: expanded;
     letter-spacing: 0.08em;
     text-transform: uppercase;
 }
@@ -87,5 +91,5 @@
 .archive__tags-link:not([href]) {
     color: black;
     font-weight: 900;
-    font-family: 'Dewi Expanded';
+    font-stretch: expanded;
 }

--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -23,7 +23,7 @@
     margin-top: 32px;
     margin-bottom: 16px;
     font-size: 16px;
-    font-family: 'Dewi Expanded', sans-serif;
+    font-stretch: expanded;
     line-height: 1.2;
     letter-spacing: 0.08em;
     text-transform: uppercase;
@@ -164,7 +164,7 @@
     left: 0;
     color: var(--color-grey-lighter);
     font-size: 16px;
-    font-family: 'Dewi Expanded', sans-serif;
+    font-stretch: expanded;
     content: '—';
 }
 
@@ -187,7 +187,7 @@
     left: 0;
     color: var(--color-grey-lighter);
     font-size: 16px;
-    font-family: 'Dewi Expanded', sans-serif;
+    font-stretch: expanded;
     counter-increment: list;
     content: counter(list);
 }
@@ -389,7 +389,7 @@
     color: var(--color-grey-medium);
     font-weight: normal;
     font-size: 3.5em;
-    font-family: 'Dewi Expanded', sans-serif;
+    font-stretch: expanded;
     line-height: 0.65;
 }
 

--- a/src/styles/blocks/links.css
+++ b/src/styles/blocks/links.css
@@ -44,7 +44,7 @@
     margin: 0 0 15px 0;
     font-weight: bold;
     font-size: 18px;
-    font-family: 'Dewi Expanded', sans-serif;
+    font-stretch: expanded;
     text-transform: uppercase;
 }
 

--- a/src/styles/blocks/menu.css
+++ b/src/styles/blocks/menu.css
@@ -134,7 +134,7 @@
 .menu__link--current {
     color: black;
     font-weight: bold;
-    font-family: 'Dewi Expanded', sans-serif;
+    font-stretch: expanded;
     text-decoration: none;
 }
 

--- a/src/styles/blocks/not-found.css
+++ b/src/styles/blocks/not-found.css
@@ -12,7 +12,9 @@
 
 .not-found__title {
     margin: 49px 0 66px;
-    font: 400 24px 'Dewi Expanded', sans-serif;
+    font-weight: 400;
+    font-size: 24px;
+    font-stretch: expanded;
     letter-spacing: -0.05em;
     text-align: center;
     text-transform: uppercase;

--- a/src/styles/blocks/related-articles.css
+++ b/src/styles/blocks/related-articles.css
@@ -14,7 +14,7 @@
     margin: 0 0 16px;
     padding: 0 16px;
     font-size: 16px;
-    font-family: 'Dewi Expanded', sans-serif;
+    font-stretch: expanded;
     line-height: 1.2;
     letter-spacing: 0.08em;
     text-transform: uppercase;

--- a/src/styles/fonts.css
+++ b/src/styles/fonts.css
@@ -101,9 +101,10 @@
 
 @font-face {
     font-weight: normal;
-    font-family: 'Dewi Expanded';
+    font-family: 'Dewi';
     font-style: normal;
     font-display: swap;
+    font-stretch: expanded;
     src: url('/fonts/dewi-expanded-regular-latin.woff2') format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -112,9 +113,10 @@
 
 @font-face {
     font-weight: normal;
-    font-family: 'Dewi Expanded';
+    font-family: 'Dewi';
     font-style: normal;
     font-display: swap;
+    font-stretch: expanded;
     src: url('/fonts/dewi-expanded-regular-latin-extended.woff2') format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -123,9 +125,10 @@
 
 @font-face {
     font-weight: normal;
-    font-family: 'Dewi Expanded';
+    font-family: 'Dewi';
     font-style: normal;
     font-display: swap;
+    font-stretch: expanded;
     src: url('/fonts/dewi-expanded-regular-cyrillic.woff2') format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }
@@ -134,9 +137,10 @@
 
 @font-face {
     font-weight: bold;
-    font-family: 'Dewi Expanded';
+    font-family: 'Dewi';
     font-style: normal;
     font-display: swap;
+    font-stretch: expanded;
     src: url('/fonts/dewi-expanded-bold-latin.woff2') format('woff2');
     unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
@@ -145,9 +149,10 @@
 
 @font-face {
     font-weight: bold;
-    font-family: 'Dewi Expanded';
+    font-family: 'Dewi';
     font-style: normal;
     font-display: swap;
+    font-stretch: expanded;
     src: url('/fonts/dewi-expanded-bold-latin-extended.woff2') format('woff2');
     unicode-range: U+0100-024F, U+0259, U+1E00-1EFF, U+2020, U+20A0-20AB, U+20AD-20CF, U+2113, U+2C60-2C7F, U+A720-A7FF;
 }
@@ -156,9 +161,10 @@
 
 @font-face {
     font-weight: bold;
-    font-family: 'Dewi Expanded';
+    font-family: 'Dewi';
     font-style: normal;
     font-display: swap;
+    font-stretch: expanded;
     src: url('/fonts/dewi-expanded-bold-cyrillic.woff2') format('woff2');
     unicode-range: U+0400-045F, U+0490-0491, U+04B0-04B1, U+2116;
 }


### PR DESCRIPTION
Здоровья!

Предлагаю использовать в дескрипторах `@font-face` свойство `font-stretch: expanded` для шрифтов _"Dewi Expanded"_.  Это позволит удалить явные указания `font-family: 'Dewi Expanded'` и управлять растяжением через `font-stretch: expanded`.