### PR TITLE
Правки адаптива блока с авторами.

### DIFF
--- a/src/layouts/article.njk
+++ b/src/layouts/article.njk
@@ -54,7 +54,7 @@ layout: page.njk
                     {% set personPhoto = 'person.png' %}
                 {% endif %}
                 {% if person.url %}
-                    <a class="creators__author"
+                    <a class="creators__cell creators__author"
                         href="{{ person.url }}">
                         <span class="creators__author-avatar blob {% blob person.name %}">
                             <img class="blob__photo"
@@ -66,7 +66,7 @@ layout: page.njk
                         </span>
                     </a>
                 {% else %}
-                    <span class="creators__author">
+                    <span class="creators__cell creators__author">
                         <span class="creators__author-avatar blob {% blob person.name %}">
                             <img class="blob__photo"
                                 src="/people/{{ personPhoto }}"
@@ -80,7 +80,7 @@ layout: page.njk
             {% endfor %}
 
             {% if translators %}
-                <p class="creators__collaborators">
+                <p class="creators__cell creators__collaborators">
                     <span class="creators__collaborators-heading">Перевод</span>
                     {%- for translator in translatorsData -%}
                         {% if translator.url %}
@@ -99,7 +99,7 @@ layout: page.njk
             {% endif %}
 
             {% if editors %}
-                <p class="creators__collaborators">
+                <p class="creators__cell creators__collaborators">
                     <span class="creators__collaborators-heading">Редактура</span>
                     {%- for editor in editorsData -%}
                         {% if editor.url %}

--- a/src/layouts/article.njk
+++ b/src/layouts/article.njk
@@ -47,7 +47,7 @@ layout: page.njk
             {% endif %}
         </div>
         <div class="article__creators creators">
-            <div class="creators__cell">
+            <div class="creators__block">
                 {% for person in authorData %}
                     {% if person.photo %}
                         {% set personPhoto = [author, '/photo.jpg'] | join %}
@@ -82,7 +82,7 @@ layout: page.njk
             </div>
 
             {% if translators %}
-                <p class="creators__cell creators__collaborators">
+                <p class="creators__block creators__collaborators">
                     <span class="creators__collaborators-heading">Перевод</span>
                     {%- for translator in translatorsData -%}
                         {% if translator.url %}
@@ -101,7 +101,7 @@ layout: page.njk
             {% endif %}
 
             {% if editors %}
-                <p class="creators__cell creators__collaborators">
+                <p class="creators__block creators__collaborators">
                     <span class="creators__collaborators-heading">Редактура</span>
                     {%- for editor in editorsData -%}
                         {% if editor.url %}

--- a/src/layouts/article.njk
+++ b/src/layouts/article.njk
@@ -47,37 +47,39 @@ layout: page.njk
             {% endif %}
         </div>
         <div class="article__creators creators">
-            {% for person in authorData %}
-                {% if person.photo %}
-                    {% set personPhoto = [author, '/photo.jpg'] | join %}
-                {% else %}
-                    {% set personPhoto = 'person.png' %}
-                {% endif %}
-                {% if person.url %}
-                    <a class="creators__cell creators__author"
-                        href="{{ person.url }}">
-                        <span class="creators__author-avatar blob {% blob person.name %}">
-                            <img class="blob__photo"
-                                src="/people/{{ personPhoto }}"
-                                width="113" height="104" alt="{{ person.name }}">
+            <div class="creators__cell">
+                {% for person in authorData %}
+                    {% if person.photo %}
+                        {% set personPhoto = [author, '/photo.jpg'] | join %}
+                    {% else %}
+                        {% set personPhoto = 'person.png' %}
+                    {% endif %}
+                    {% if person.url %}
+                        <a class="creators__author"
+                            href="{{ person.url }}">
+                            <span class="creators__author-avatar blob {% blob person.name %}">
+                                <img class="blob__photo"
+                                    src="/people/{{ personPhoto }}"
+                                    width="113" height="104" alt="{{ person.name }}">
+                            </span>
+                            <span class="creators__author-name" itemprop="author">
+                                {{ person.name }}
+                            </span>
+                        </a>
+                    {% else %}
+                        <span class="creators__author">
+                            <span class="creators__author-avatar blob {% blob person.name %}">
+                                <img class="blob__photo"
+                                    src="/people/{{ personPhoto }}"
+                                    width="113" height="104" alt="{{ person.name }}">
+                            </span>
+                            <span class="creators__author-name" itemprop="author">
+                                {{ person.name }}
+                            </span>
                         </span>
-                        <span class="creators__author-name" itemprop="author">
-                            {{ person.name }}
-                        </span>
-                    </a>
-                {% else %}
-                    <span class="creators__cell creators__author">
-                        <span class="creators__author-avatar blob {% blob person.name %}">
-                            <img class="blob__photo"
-                                src="/people/{{ personPhoto }}"
-                                width="113" height="104" alt="{{ person.name }}">
-                        </span>
-                        <span class="creators__author-name" itemprop="author">
-                            {{ person.name }}
-                        </span>
-                    </span>
-                {% endif %}
-            {% endfor %}
+                    {% endif %}
+                {% endfor %}
+            </div>
 
             {% if translators %}
                 <p class="creators__cell creators__collaborators">

--- a/src/styles/blocks/article.css
+++ b/src/styles/blocks/article.css
@@ -275,7 +275,6 @@
 .article__creators {
     max-width: 700px;
     margin: 0 auto 48px;
-    padding: 0 16px;
 }
 
 @media (min-width: 1240px) {

--- a/src/styles/blocks/creators.css
+++ b/src/styles/blocks/creators.css
@@ -1,32 +1,26 @@
 .creators {
     display: flex;
+    flex-wrap: wrap;
+    align-content: flex-start;
 }
 
-@media (min-width: 1024px) {
-    .creators {
-        line-height: 1.6;
-    }
-}
-
-@media (min-width: 1240px) {
-    .creators {
-        flex-direction: column;
-        align-items: flex-start;
-    }
+.creators__cell {
+    --creators-breakpoint: 460px;
+    margin: 0 16px;
+    flex-grow: 1;
+    flex-shrink: 1;
+    /* Описание техники:
+        * https://www.freecodecamp.org/news/the-fab-four-technique-to-create-responsive-emails-without-media-queries-baf11fdfa848/
+        * https://heydonworks.com/article/the-flexbox-holy-albatross/
+    */
+    flex-basis: calc((var(--creators-breakpoint) - 100%) * 9999);
 }
 
 .creators__author {
-    margin-right: 32px;
+    margin-bottom: 19px;
     color: var(--color-grey-darker);
     letter-spacing: 0.05em;
     text-transform: uppercase;
-}
-
-@media (min-width: 1240px) {
-    .creators__author {
-        margin-right: 0;
-        margin-bottom: 19px;
-    }
 }
 
 .creators__author:link {
@@ -77,20 +71,9 @@
 }
 
 .creators__collaborators {
+    margin-bottom: 17px;
     display: flex;
     flex-direction: column;
-    margin: 0;
-}
-
-.creators__collaborators:not(:last-child) {
-    margin-right: 32px;
-}
-
-@media (min-width: 1240px) {
-    .creators__collaborators:not(:last-child) {
-        margin-right: 0;
-        margin-bottom: 17px;
-    }
 }
 
 .creators__collaborators-heading {
@@ -107,6 +90,10 @@
 
 .creators__collaborators-link:visited {
     color: var(--color-grey-medium);
+}
+
+.creators__collaborators-link:not(:last-child) {
+    margin-top: 4px;
 }
 
 @media (hover: hover) and (pointer: fine) {

--- a/src/styles/blocks/creators.css
+++ b/src/styles/blocks/creators.css
@@ -6,14 +6,15 @@
 
 .creators__cell {
     --creators-breakpoint: 460px;
-    margin: 0 16px;
     flex-grow: 1;
     flex-shrink: 1;
+
     /* Описание техники:
-        * https://www.freecodecamp.org/news/the-fab-four-technique-to-create-responsive-emails-without-media-queries-baf11fdfa848/
-        * https://heydonworks.com/article/the-flexbox-holy-albatross/
+        - https://www.freecodecamp.org/news/the-fab-four-technique-to-create-responsive-emails-without-media-queries-baf11fdfa848/
+        - https://heydonworks.com/article/the-flexbox-holy-albatross/
     */
     flex-basis: calc((var(--creators-breakpoint) - 100%) * 9999);
+    margin: 0 16px;
 }
 
 .creators__author {
@@ -71,9 +72,9 @@
 }
 
 .creators__collaborators {
-    margin-bottom: 17px;
     display: flex;
     flex-direction: column;
+    margin-bottom: 17px;
 }
 
 .creators__collaborators-heading {

--- a/src/styles/blocks/creators.css
+++ b/src/styles/blocks/creators.css
@@ -6,6 +6,7 @@
 
 .creators__cell {
     --creators-breakpoint: 460px;
+    display: flex;
     flex-grow: 1;
     flex-shrink: 1;
 
@@ -14,7 +15,6 @@
         - https://heydonworks.com/article/the-flexbox-holy-albatross/
     */
     flex-basis: calc((var(--creators-breakpoint) - 100%) * 9999);
-    display: flex;
     flex-direction: column;
     align-items: flex-start;
     margin: 0 16px;

--- a/src/styles/blocks/creators.css
+++ b/src/styles/blocks/creators.css
@@ -14,6 +14,9 @@
         - https://heydonworks.com/article/the-flexbox-holy-albatross/
     */
     flex-basis: calc((var(--creators-breakpoint) - 100%) * 9999);
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
     margin: 0 16px;
 }
 

--- a/src/styles/blocks/creators.css
+++ b/src/styles/blocks/creators.css
@@ -4,7 +4,7 @@
     align-content: flex-start;
 }
 
-.creators__cell {
+.creators__block {
     --creators-breakpoint: 460px;
     display: flex;
     flex-grow: 1;

--- a/src/styles/blocks/creators.css
+++ b/src/styles/blocks/creators.css
@@ -74,6 +74,7 @@
 .creators__collaborators {
     display: flex;
     flex-direction: column;
+    align-items: flex-start;
     margin-bottom: 17px;
 }
 
@@ -94,7 +95,7 @@
 }
 
 .creators__collaborators-link:not(:last-child) {
-    margin-top: 4px;
+    margin-bottom: 4px;
 }
 
 @media (hover: hover) and (pointer: fine) {


### PR DESCRIPTION
@akellbl4 уже делал правки в этом [MR#203](https://github.com/web-standards-ru/web-standards.ru/pull/203) для бага #192, но предлагаю другой подход.

Используется техника, эмулирующая container queries. Описана в статьях [Rémi Parmentier]() и [Heydon Pickering](https://heydonworks.com/article/the-flexbox-holy-albatross/). Метод позволяет отказаться от media queries и использовать для настройки всего лишь одного число - `--creators-breakpoint`.

Также сделал небольшие правки типографики, так как при длинных именах строки "слипаются".

Прикладываю скрины, что получилось (скроллбар возникает из-за `.article__heading-wrapper` - поправим позже):
<details>
  <summary>скрины</summary>  

  ![image](https://user-images.githubusercontent.com/6412192/112369658-427cf780-8cfe-11eb-9ab3-6b74ef484c6a.png)  

 ![image](https://user-images.githubusercontent.com/6412192/112369818-7821e080-8cfe-11eb-836c-8e231e0718ba.png)

 ![image](https://user-images.githubusercontent.com/6412192/112369850-8112b200-8cfe-11eb-9bac-552418bf9efa.png)
 
![image](https://user-images.githubusercontent.com/6412192/112369891-8d970a80-8cfe-11eb-9ff3-15b83422a2b3.png)
 
![image](https://user-images.githubusercontent.com/6412192/112369955-a0a9da80-8cfe-11eb-8fd8-47e92736f455.png)
 
![image](https://user-images.githubusercontent.com/6412192/112369976-aa334280-8cfe-11eb-919a-b3f5da91af6c.png)

 ![image](https://user-images.githubusercontent.com/6412192/112370029-b9b28b80-8cfe-11eb-95a9-a425cfb783e9.png)

</details>