### PR TITLE
Ставит figcaption ближе к картинкам

### DIFF
--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -210,6 +210,12 @@
     font-size: 0.8em;
 }
 
+@media (min-width: 1240px) {
+    .content figure {
+        margin: 60px 0;
+    }
+}
+
 /* Images */
 
 .content img,
@@ -224,6 +230,10 @@
     .content img,
     .content video {
         margin: 60px 0;
+    }
+    
+    .content figure img {
+        margin: 0 0 16px;
     }
 }
 

--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -231,7 +231,7 @@
     .content video {
         margin: 60px 0;
     }
-    
+
     .content figure img {
         margin: 0 0 16px;
     }


### PR DESCRIPTION
Вот [тут](https://web-standards.ru/articles/native-and-custom-select/) очень заметно, что подписи к картинкам стоят ближе к тексту, чем к самим картинкам. Нарушается принцип близости из дизайна. Давайте починим.