### PR TITLE
Пагинация только по коллекции `tagList` на странице тегов

### DIFF
--- a/src/pages/tag.njk
+++ b/src/pages/tag.njk
@@ -1,13 +1,8 @@
 ---
 pagination:
-    data: collections
+    data: collections.tagList
     size: 1
     alias: tag
-    filter:
-        - all
-        - articles
-        - tagList
-    addAllPagesToCollections: true
 renderData:
     title: Статьи с тегом «{{ tag }}»
 layout: page.njk


### PR DESCRIPTION
Упустил такой момент в прошлом PR: поскольку сейчас теги используются только для категорий статей, то и лишние фильтрации на странице `tag.njk` не нужны.