### PR TITLE
Меняет сетку блока «Ещё» (Статьи по теме)

### DIFF
--- a/src/styles/blocks/articles.css
+++ b/src/styles/blocks/articles.css
@@ -61,12 +61,11 @@
 
 @media (min-width: 800px) {
     .articles--related {
-        display: flex;
-        flex-wrap: wrap;
+        display: grid;
+        grid-template-columns: repeat(auto-fit, minmax(234px, 1fr));
     }
 
     .articles__item--related {
-        flex: 1 1 200px;
         margin-top: 1px;
         margin-left: 1px;
         padding: 16px 32px 32px 24px;

--- a/src/styles/blocks/articles.css
+++ b/src/styles/blocks/articles.css
@@ -61,8 +61,8 @@
 
 @media (min-width: 800px) {
     .articles--related {
-        display: grid;
-        grid-template-columns: 1fr 1fr 1fr;
+        display: flex;
+        flex-wrap: wrap;
     }
 
     .articles__item--related {
@@ -71,6 +71,7 @@
         padding: 16px 32px 32px 24px;
         border: none;
         box-shadow: 0 0 0 1px var(--color-grey-lighter);
+        flex: 1 1 200px;
     }
 
     .articles__item--related:last-of-type {

--- a/src/styles/blocks/articles.css
+++ b/src/styles/blocks/articles.css
@@ -66,12 +66,12 @@
     }
 
     .articles__item--related {
+        flex: 1 1 200px;
         margin-top: 1px;
         margin-left: 1px;
         padding: 16px 32px 32px 24px;
         border: none;
         box-shadow: 0 0 0 1px var(--color-grey-lighter);
-        flex: 1 1 200px;
     }
 
     .articles__item--related:last-of-type {

--- a/src/styles/blocks/main.css
+++ b/src/styles/blocks/main.css
@@ -20,6 +20,12 @@
     }
 }
 
+@media (min-width: 800px) and (max-width: 1023px) {
+    .main__related-articles {
+        margin-bottom: 37px;
+    }
+}
+
 .main__conference-link {
     margin-top: 40px;
 }

--- a/src/styles/blocks/related-articles.css
+++ b/src/styles/blocks/related-articles.css
@@ -1,7 +1,7 @@
 .related-articles {
     max-width: 700px;
-    margin-left: auto;
     margin-right: auto;
+    margin-left: auto;
 }
 
 @media (min-width: 1240px) {

--- a/src/styles/blocks/related-articles.css
+++ b/src/styles/blocks/related-articles.css
@@ -1,6 +1,7 @@
 .related-articles {
     max-width: 700px;
-    margin: 0 auto;
+    margin-left: auto;
+    margin-right: auto;
 }
 
 @media (min-width: 1240px) {


### PR DESCRIPTION
**[Cсылка на ишью](https://github.com/web-standards-ru/web-standards.ru/issues/272)** (я не могу связать)

На размерах экрана 800-1024 у статьей из блока "Ещё" наблюдалось пара проблем:
1. Появлялся скролл, так как контент не влезал
2. Карточки прилипали к футеру, не было воздуха

Решил заменить сетку из гридов на флексовый «[Деконструированный блин](https://moderncss.dev/container-query-solutions-with-css-grid-and-flexbox/#flexbox-solution-#2)».

<details>
<summary>Выглядит сейчас так:</summary>
<img src="https://user-images.githubusercontent.com/47776594/129503717-c78d584e-3790-478a-a900-919e7d5ede17.png" alt="Скриншот">
</details>

#### ❗ Важно ❗ 
Это не просто растягивание последнего блока. Если бы контента было мало, то было бы так же 3 колонки как и задумывалось. Но поскольку в карточках много контента, то браузер сам решает что надо перенести на следующую строку, так как не влезает. И растягивает на всю ширину по `flex-grow`, чтобы не было некрасивой дырки.
Как раз подходит под принцип, что дизайн подстраивается под контент. 

Отступ в 37px взял из закомментированной строчки в `main.css`
