### PR TITLE
Поддержка 2–3 авторов

### DIFF
--- a/src/includes/article-card.njk
+++ b/src/includes/article-card.njk
@@ -37,7 +37,8 @@
     {% for person in article.data.authorData %}
         {% if person.photo %}
             {% if article.data.authorData | length > 1 %}
-                {% set personPhoto = [article.data.author[loop.index0], '/photo.jpg'] | join %}
+                {% set orderedAuthors = article.data.author | sort() %}
+                {% set personPhoto = [orderedAuthors[loop.index0], '/photo.jpg'] | join %}
             {% else %}
                 {% set personPhoto = [article.data.author, '/photo.jpg'] | join %}
             {% endif %}

--- a/src/includes/article-card.njk
+++ b/src/includes/article-card.njk
@@ -34,40 +34,46 @@
         {{ article.date | ruDate }}
     </time>
 
-    {% for person in article.data.authorData %}
-        {% if person.photo %}
-            {% if article.data.authorData | length > 1 %}
-                {% set orderedAuthors = article.data.author | sort() %}
-                {% set personPhoto = [orderedAuthors[loop.index0], '/photo.jpg'] | join %}
-            {% else %}
-                {% set personPhoto = [article.data.author, '/photo.jpg'] | join %}
-            {% endif %}
-        {% else %}
-            {% set personPhoto = 'person.png' %}
-        {% endif %}
+    <div class="article-card__author-container {{ 'article-card__author-container--featured' if featured }}">
+        {% for person in article.data.authorData %}
+            <span class="
+                article-card__author
+                article-card__author{{ articleType }}
+                article-card__author{{ featuredClass }}">
+                {{ person.name }}{{ ', ' if not loop.last else '' }}
+            </span>
+        {% endfor %}
+    </div>
 
-        <span class="
-            article-card__author
-            article-card__author{{ articleType }}
-            article-card__author{{ featuredClass }}">
-            {{ person.name }}
-        </span>
+    {% if not featured or articleCardVariant == 'related' %}
+        <div class="article-card__avatar-container">
+            {% for person in article.data.authorData %}
+                {% if person.photo %}
+                    {% if article.data.authorData | length > 1 %}
+                        {% set orderedAuthors = article.data.author | sort() %}
+                        {% set personPhoto = [orderedAuthors[loop.index0], '/photo.jpg'] | join %}
+                    {% else %}
+                        {% set personPhoto = [article.data.author, '/photo.jpg'] | join %}
+                    {% endif %}
+                {% else %}
+                    {% set personPhoto = 'person.png' %}
+                {% endif %}
 
-        {% if not featured or articleCardVariant == 'related' %}
-            <div class="
-                article-card__avatar
-                article-card__avatar{{ articleType }}
-                blob {% blob person.name %}">
-                <img class="
-                        article-card__photo
-                        article-card__photo{{ articleType }}
-                        blob__photo"
-                    src="/people/{{ personPhoto }}"
-                    width="80" height="74"
-                    alt="{{ person.name }}">
-            </div>
-        {% endif %}
-    {% endfor %}
+                <div class="
+                    article-card__avatar
+                    article-card__avatar{{ articleType }}
+                    blob {% blob person.name %}">
+                    <img class="
+                            article-card__photo
+                            article-card__photo{{ articleType }}
+                            blob__photo"
+                        src="/people/{{ personPhoto }}"
+                        width="80" height="74"
+                        alt="{{ person.name }}">
+                </div>
+            {% endfor %}
+        </div>
+    {% endif %}
 
     {% if featured and articleCardVariant !== 'related' %}
         {% if article.data.hero.src %}

--- a/src/includes/article-card.njk
+++ b/src/includes/article-card.njk
@@ -36,7 +36,11 @@
 
     {% for person in article.data.authorData %}
         {% if person.photo %}
-            {% set personPhoto = [article.data.author, '/photo.jpg'] | join %}
+            {% if article.data.authorData | length > 1 %}
+                {% set personPhoto = [article.data.author[loop.index0], '/photo.jpg'] | join %}
+            {% else %}
+                {% set personPhoto = [article.data.author, '/photo.jpg'] | join %}
+            {% endif %}
         {% else %}
             {% set personPhoto = 'person.png' %}
         {% endif %}

--- a/src/layouts/article.njk
+++ b/src/layouts/article.njk
@@ -50,7 +50,11 @@ layout: page.njk
             <div class="creators__block">
                 {% for person in authorData %}
                     {% if person.photo %}
-                        {% set personPhoto = [author, '/photo.jpg'] | join %}
+                        {% if authorData | length > 1 %}
+                            {% set personPhoto = [author[loop.index0], '/photo.jpg'] | join %}
+                        {% else %}
+                            {% set personPhoto = [author, '/photo.jpg'] | join %}
+                        {% endif %}
                     {% else %}
                         {% set personPhoto = 'person.png' %}
                     {% endif %}

--- a/src/layouts/article.njk
+++ b/src/layouts/article.njk
@@ -51,7 +51,8 @@ layout: page.njk
                 {% for person in authorData %}
                     {% if person.photo %}
                         {% if authorData | length > 1 %}
-                            {% set personPhoto = [author[loop.index0], '/photo.jpg'] | join %}
+                            {% set orderedAuthors = author | sort() %}
+                            {% set personPhoto = [orderedAuthors[loop.index0], '/photo.jpg'] | join %}
                         {% else %}
                             {% set personPhoto = [author, '/photo.jpg'] | join %}
                         {% endif %}

--- a/src/styles/blocks/article-card.css
+++ b/src/styles/blocks/article-card.css
@@ -13,6 +13,7 @@
 
 @media (min-width: 460px) {
     .article-card {
+        grid-template-rows: min-content 1fr;
         grid-template-areas:
             'picture title title'
             'picture date author';
@@ -35,18 +36,29 @@
     }
 }
 
+.article-card__avatar-container {
+    grid-area: picture;
+}
+
 .article-card__avatar {
     position: relative;
-    grid-area: picture;
     width: 80px;
     height: 80px;
     object-fit: cover;
+}
+
+.article-card__avatar:not(:first-child) {
+    margin-top: -32px;
 }
 
 @media (min-width: 1024px) {
     .article-card__avatar {
         width: 112px;
         height: 112px;
+    }
+
+    .article-card__avatar:not(:first-child) {
+        margin-top: -48px;
     }
 }
 
@@ -95,6 +107,10 @@
     .article-card__author {
         font-size: 16px;
     }
+
+    .article-card__author {
+        display: block;
+    }
 }
 
 .article-card__date {
@@ -102,8 +118,11 @@
     color: var(--color-grey-medium);
 }
 
-.article-card__author {
+.article-card__author-container {
     grid-area: author;
+}
+
+.article-card__author {
     color: var(--color-grey-darker);
     text-transform: uppercase;
 }
@@ -208,8 +227,9 @@
     line-height: 1.3;
 }
 
+.article-card__author-container--featured,
 .article-card__date--featured,
-.article-card__author--featured {
+.article-card__hero-image--featured {
     align-self: flex-end;
 }
 
@@ -225,5 +245,9 @@
 @media (min-width: 800px) {
     .article-card__preview {
         min-height: 5em;
+    }
+
+    .article-card__author--featured {
+        display: inline;
     }
 }

--- a/src/styles/blocks/article-card.css
+++ b/src/styles/blocks/article-card.css
@@ -118,6 +118,11 @@
     color: var(--color-grey-medium);
 }
 
+.article-card__date,
+.article-card__author-container {
+    align-self: baseline;
+}
+
 .article-card__author-container {
     grid-area: author;
 }


### PR DESCRIPTION
Решение для #143.

Вроде бы всё основное сделала.

Единственное, что не могу нормально решить, — выравнивание имён и даты в обычных карточках на ширине вьюпорта с 800 и до 460, когда они выстраиваются рядом в две колонки. Колонка с именами располагается чуть ниже, чем дата. Я добавила для `span` с авторами обёртку `div`, что как раз и привело к этой проблеме. 
1) Это исправляет `line-height: 1` для блока-обёртки, но кажется, что это костыльное решение. К тому же, оно влияет на расстояние между элементами со `span`.
2) Второй вариант — `flex` или `inline-flex` для всё той же обёртки. Но тогда для детей нужно будет задавать отступы руками.

![problem](https://user-images.githubusercontent.com/17615202/150230639-2b7faaea-da30-4a7a-84d1-85686c0fb9cb.png)

