### PR TITLE
Добавляет ссылку на RSS-ленту подкаста как `<link rel="alternate" />`

### DIFF
--- a/src/data/site.js
+++ b/src/data/site.js
@@ -4,7 +4,8 @@ module.exports = {
     'description': 'Авторские и переводные статьи по фронтенду',
     'paths': {
         'site': 'https://web-standards.ru',
-        'feed': 'https://web-standards.ru/articles/feed/',
+        'articlesFeed': 'https://web-standards.ru/articles/feed/',
+        'podcastsFeed': 'https://web-standards.ru/podcast/feed/',
         'social': 'https://web-standards.ru/images/social.png',
     },
     'buildYear': new Date().getFullYear(),

--- a/src/layouts/page.njk
+++ b/src/layouts/page.njk
@@ -20,7 +20,8 @@
     {% include 'open-graph.njk' %}
     {% include 'icons.njk' %}
 
-    <link rel="alternate" href="{{ site.paths.feed }}" type="application/rss+xml" title="Новости — Веб-стандарты">
+    <link rel="alternate" href="{{ site.paths.articlesFeed }}" type="application/rss+xml" title="Статьи — Веб-стандарты">
+    <link rel="alternate" href="{{ site.paths.podcastsFeed }}" type="application/rss+xml" title="Подкасты — Веб-стандарты">
     <link rel="manifest" href="/manifest.json">
     <link rel="stylesheet" href="/styles/styles.css">
     <link rel="stylesheet" href="/styles/print.css" media="print">


### PR DESCRIPTION
В HTML страниц сайта есть ссылка на RSS статей, но нет RSS подкаста. Этот PR добавляет такую ссылку.

Вот примеры, как будет выглядеть парсинг RSS, когда мы указываем сам сайт `https://web-standards.ru`

<details>
 <summary>Inoreader</summary>

  ![inoreader](https://user-images.githubusercontent.com/6412192/179976231-bd614f26-352d-4de0-b9de-c50e96b890cd.jpg)
</details>

<details>
 <summary>Feedly</summary>

  ![feedly](https://user-images.githubusercontent.com/6412192/179976193-2491ccf8-2328-4588-8c65-e96fb3a68b88.jpg)
</details>

P.S.: Возможно, стоит поправить заголовок в репозитории подкаста, чтобы он лучше распознавался в сервисах, например "Веб-стандарты – Подкасты".



