### PR TITLE
Исправляет опечатку в статье про OKLCH

### DIFF
--- a/src/articles/oklch-in-css-why-quit-rgb-hsl/index.md
+++ b/src/articles/oklch-in-css-why-quit-rgb-hsl/index.md
@@ -69,7 +69,7 @@ featured: true
 
 ```css
 a:hover {
-    /* голубой */
+    /* синий */
     background: oklch(45% 0.26 264);
     /* белый */
     color: oklch(100% 0 0);


### PR DESCRIPTION
В языковом сознании русскоговорящих людей `blue` может значить как голубой, так и синий.

<img width="847" alt="image" src="https://user-images.githubusercontent.com/4586392/219435562-d49ece9b-e8f1-4222-b24d-c1ba7293fcfa.png">
