### PR TITLE
Правит адаптив для элементов шапки

### DIFF
--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -29,7 +29,7 @@
 
 /* Logo */
 
-@media (max-width: 735px) {
+@media (width < 736px) {
     .header__logo {
         z-index: 1;
     }
@@ -48,7 +48,7 @@
 
 /* Menu */
 
-@media (max-width: 735px) {
+@media (width < 736px) {
     .header__menu {
         position: absolute;
         top: 0;

--- a/src/styles/blocks/logo.css
+++ b/src/styles/blocks/logo.css
@@ -43,7 +43,7 @@
     letter-spacing: -0.03em;
 }
 
-@media (max-width: 735px) {
+@media (width < 736px) {
     .logo__title {
         align-self: center;
     }
@@ -78,7 +78,7 @@
     text-transform: uppercase;
 }
 
-@media (max-width: 735px) {
+@media (width < 736px) {
     .logo__tagline {
         display: none;
     }

--- a/src/styles/blocks/menu.css
+++ b/src/styles/blocks/menu.css
@@ -1,6 +1,6 @@
 /* Menu */
 
-@media (max-width: 735px) {
+@media (width < 736px) {
     .menu {
         display: grid;
     }
@@ -8,7 +8,7 @@
 
 /* Button */
 
-@media (max-width: 735px) {
+@media (width < 736px) {
     .menu__button {
         z-index: 1;
         display: block;
@@ -30,7 +30,7 @@
 
 /* Icon */
 
-@media (max-width: 735px) {
+@media (width < 736px) {
     .menu__icon {
         display: block;
         stroke: black;
@@ -60,7 +60,7 @@
     list-style: none;
 }
 
-@media (max-width: 735px) {
+@media (width < 736px) {
     .menu__list {
         display: none;
         row-gap: 12px;


### PR DESCRIPTION
Правит [баг, связанный с адаптивом шапки](https://github.com/web-standards-ru/web-standards.ru/issues/270).

Используется современный  range-синтаксис media-выражений, который сейчас [поддерживается](https://caniuse.com/css-media-range-syntax) во всех браузерах.

Менял только для тех блоков, что вызывают проблемы.

Другие PR c решениями:
- https://github.com/web-standards-ru/web-standards.ru/pull/271
- https://github.com/web-standards-ru/web-standards.ru/pull/286