### PR TITLE
Исправляет наложение интерактивных элементов в шапке на мобильных

### DIFF
--- a/src/styles/blocks/header.css
+++ b/src/styles/blocks/header.css
@@ -32,6 +32,7 @@
 @media (max-width: 735px) {
     .header__logo {
         z-index: 1;
+        width: fit-content;
     }
 }
 


### PR DESCRIPTION
На экранах больше 736px ширину `.header__logo` ограничивал `display: grid`; у `.header`, на мобильных ограничений ширины у `.header__logo` не было, исправил, добавил нужное свойство.