### PR TITLE
Правки для страницы списка статей

### DIFF
--- a/src/includes/article-card.njk
+++ b/src/includes/article-card.njk
@@ -68,7 +68,8 @@
                             article-card__photo{{ articleType }}
                             blob__photo"
                         src="/people/{{ personPhoto }}"
-                        width="80" height="74"
+                        width="80" height="80"
+                        {% if articleType === '--articles' %}loading="lazy"{% endif %}
                         alt="{{ person.name }}">
                 </div>
             {% endfor %}

--- a/src/styles/blocks/article-card.css
+++ b/src/styles/blocks/article-card.css
@@ -40,6 +40,12 @@
     grid-area: picture;
 }
 
+@media (min-width: 800px) {
+    .article-card__avatar-container {
+        align-self: start;
+    }
+}
+
 .article-card__avatar {
     position: relative;
     width: 80px;


### PR DESCRIPTION
Правит атрибуты размеров для аватарок - делает их квадратными. Добавляет `loading="lazy"`, чтобы не грузить большое число картинок при первом открытии страницы.

Правит выравнивание аватарки в Chrome/Safari. Как сейчас это выглядит на https://web-standards.ru/articles/:
<details>
  <summary>Firefox</summary>  
  <img width="1273" alt="image" src="https://github.com/web-standards-ru/web-standards.ru/assets/6412192/a323a3b1-7a11-4bc3-873a-d2afbe7ad25d">

</details>
<details>
  <summary>Chrome/Safari</summary>  
  <img width="1268" alt="image" src="https://github.com/web-standards-ru/web-standards.ru/assets/6412192/a30f8760-84cb-4515-af2c-bf49b91a734b">

</details>