### PR TITLE
Правит аватары в статье

### DIFF
--- a/src/layouts/article.njk
+++ b/src/layouts/article.njk
@@ -65,7 +65,7 @@ layout: page.njk
                             <span class="creators__author-avatar blob {% blob person.name %}">
                                 <img class="blob__photo"
                                     src="/people/{{ personPhoto }}"
-                                    width="113" height="104" alt="{{ person.name }}">
+                                    width="100" height="100" alt="{{ person.name }}">
                             </span>
                             <span class="creators__author-name" itemprop="author">
                                 {{ person.name }}
@@ -76,7 +76,7 @@ layout: page.njk
                             <span class="creators__author-avatar blob {% blob person.name %}">
                                 <img class="blob__photo"
                                     src="/people/{{ personPhoto }}"
-                                    width="113" height="104" alt="{{ person.name }}">
+                                    width="100" height="100" alt="{{ person.name }}">
                             </span>
                             <span class="creators__author-name" itemprop="author">
                                 {{ person.name }}

--- a/src/styles/blocks/blob.css
+++ b/src/styles/blocks/blob.css
@@ -72,4 +72,5 @@
         grayscale(1)
         brightness(1.1)
         contrast(1.3);
+    object-fit: cover;
 }

--- a/src/styles/blocks/creators.css
+++ b/src/styles/blocks/creators.css
@@ -53,7 +53,6 @@
     width: 100px;
     height: 100px;
     margin-bottom: 26px;
-    object-fit: cover;
 }
 
 @media (min-width: 1024px) {

--- a/src/styles/print.css
+++ b/src/styles/print.css
@@ -135,10 +135,6 @@ figure {
     margin-bottom: 10px;
 }
 
-.blob::before {
-    display: none;
-}
-
 .blob__photo {
     mix-blend-mode: normal;
 }


### PR DESCRIPTION
Правки:

- Задаёт одинаковые размеры атрибутов `width` и `height` для аватаров в статье. Видимо, ранее дизайн был другой и они остались
- Переносит `object-fit: cover` с контейнера, содержащего `img`, на само изображение `img`
- Удаляет лишние стили в `print.css`, так как декоративыне элементы аватарок больше не создаются с помощью псевдоэлементов