### PR TITLE
Удаляет дубликат `aria-label` для кнопки копирования URL

### DIFF
--- a/eleventy.config.js
+++ b/eleventy.config.js
@@ -13,9 +13,6 @@ module.exports = function(config) {
         permalinkClass: 'tooltip__button',
         permalinkSymbol: '',
         permalinkSpace: false,
-        permalinkAttrs: () => ({
-            'aria-label': 'Этот заголовок',
-        }),
         slugify: () => 'section',
     }).use(require('markdown-it-multimd-table'));
 


### PR DESCRIPTION
Для компонента `tooltip` создаётся дубликат атрибута `aria-label` в этих местах:

https://github.com/web-standards-ru/web-standards.ru/blob/307a1452adf7b1792694a6d799284bf0ca019a33/eleventy.config.js#L16-L18

https://github.com/web-standards-ru/web-standards.ru/blob/307a1452adf7b1792694a6d799284bf0ca019a33/src/helpers/markdown-it-anchor.js#L27-L28

Браузеры в инспекторе не показывают этот дубликат, но в HTML он остаётся и на него жалуется W3C HTML validator.

Оставил этот `aria-label` - "Копировать ссылку на заголовок"