### PR TITLE
Упрощает структуру карточки-превью выпуска подкаста

### DIFF
--- a/src/includes/podcast-preview.njk
+++ b/src/includes/podcast-preview.njk
@@ -8,13 +8,8 @@
                 {{ data.title }}
             </a>
         </h3>
-        {% if data.hasPlayer %}
-            <audio class="podcast-preview__audio" src="{{ data.audio }}" controls preload="metadata"></audio>
-        {% endif %}
-        <div class="podcast-preview__meta">
-            <time class="podcast-preview__date" datetime="{{ data.date | isoDate }}">
-                {{ data.date | ruDate }}
-            </time>
-        </div>
+        <time class="podcast-preview__date" datetime="{{ data.date | isoDate }}">
+            {{ data.date | ruDate }}
+        </time>
     </article>
 {% endmacro %}

--- a/src/styles/blocks/podcast-preview.css
+++ b/src/styles/blocks/podcast-preview.css
@@ -47,10 +47,7 @@
 .podcast-preview__link::after {
     content: '';
     position: absolute;
-    top: -1px;
-    right: -1px;
-    bottom: -1px;
-    left: -1px;
+    inset: -1px;
     z-index: 1;
     border: 2px solid transparent;
     transition: border-color 0.2s;
@@ -60,12 +57,9 @@
     border-color: var(--link-hover-color);
 }
 
-.podcast-preview__meta {
+.podcast-preview__date {
     margin-top: auto;
     padding-top: 24px;
-}
-
-.podcast-preview__date {
     color: var(--meta-color);
 }
 
@@ -75,12 +69,6 @@
     color: var(--meta-color);
     font-stretch: expanded;
     text-transform: uppercase;
-}
-
-.podcast-preview__audio {
-    z-index: 1;
-    width: 100%;
-    margin-top: 24px;
 }
 
 .podcast-preview--inverse {


### PR DESCRIPTION
Правки:
- Удаляет элемент `.podcast-preview__meta` и переносит его стили на `.podcast-preview__date`
- Удаляет элемент `.podcast-preview__audio`, так как он не используется
- Оптимизирует число свойств для `.podcast-preview__link::after`