### PR TITLE
Добавляет кодировку "utf-8" для CSS

### DIFF
--- a/src/styles/styles.css
+++ b/src/styles/styles.css
@@ -1,3 +1,5 @@
+@charset 'utf-8';
+
 /* Fonts */
 
 @import 'fonts.css';


### PR DESCRIPTION
Маркеры списка используют utf-8-символы, вставленные как есть, поэтому хорошо бы сообщить браузеру, что файл закодирован именно в этой кодировке.

Возможно, решит [эту проблему](https://github.com/web-standards-ru/web-standards.ru/issues/354), но это не точно.