### PR TITLE
Изменяет поведение при выборе темы подкаста

### DIFF
--- a/src/scripts/modules/podcast.js
+++ b/src/scripts/modules/podcast.js
@@ -56,17 +56,7 @@ function handlePassedTimecode() {
 function initAnchor() {
     window.addEventListener('hashchange', () => {
         handlePassedTimecode();
-
-        if (!player.paused) {
-            playAudio();
-        }
     });
-}
-
-function playAudio() {
-    if (player.paused) {
-        player.play();
-    }
 }
 
 if (player) {

--- a/src/scripts/modules/podcast.js
+++ b/src/scripts/modules/podcast.js
@@ -56,7 +56,10 @@ function handlePassedTimecode() {
 function initAnchor() {
     window.addEventListener('hashchange', () => {
         handlePassedTimecode();
-        playAudio();
+
+        if (!player.paused) {
+            playAudio();
+        }
     });
 }
 


### PR DESCRIPTION
После выбора таймкода подкаст начинает проигрываться даже если не был изначально включен.

Такое поведение может напугать или оглушить, т.к. зачастую громкость браузерных звуков больше обычного. Так же в моём случае это мешает найти ссылку на материал по конкретной теме во время прослушивания подкаста на другом источнике.

Этот PR изменяет поведение таким образом, что при переходе между темами аудио воспроизводится только если изначально было включено.