### PR TITLE
Правит закрытие одиночных тегов в xml-фидах

### DIFF
--- a/src/eleventy-config/transforms.js
+++ b/src/eleventy-config/transforms.js
@@ -168,7 +168,7 @@ export default function(eleventyConfig) {
 
     // добавление на заголовки id с временными метками внутри страниц подкастов
     eleventyConfig.addTransform('podcast-headings', async function(content) {
-        if (this.page?.outputFileExtension !== 'html') {
+        if (!this.page?.outputPath?.endsWith?.('html')) {
             return content;
         }
 
@@ -196,7 +196,7 @@ export default function(eleventyConfig) {
 
     // добавление id на заголовки и кнопок для копирования ссылок
     eleventyConfig.addTransform('content-headings', async function(content) {
-        if (this.page?.outputFileExtension !== 'html') {
+        if (!this.page?.outputPath?.endsWith?.('html')) {
             return content;
         }
 


### PR DESCRIPTION
Для новых трансформаций для заголовков я использовал `this.page.outputFileExtension` как признак принадлежности к тому или иному типу файла. По всей видимости, Eleventy использует его для custom template engine, когда авторы указывают расширение выходных файлов.

По умолчанию, `outputFileExtension` равен `html`, поэтому условие в трансформациях не выполняется и содержимое xml-файлов обрабатывается по правилам html, и, как следствие, появляются одиночные незакрытые теги.

Переделал на проверку `this.page.outputPath`.