### PR TITLE
Рефакторит вывод `titleSuffix` и `title`

### DIFF
--- a/src/data/eleventyComputed.js
+++ b/src/data/eleventyComputed.js
@@ -1,9 +1,6 @@
 export default {
-    titleSuffix(data) {
-        return data.page.url === '/' ? '' : ' — Веб-стандарты';
-    },
-
     pageTitle(data) {
-        return data.title + data.titleSuffix;
+        const titleSuffix = data.page.url === '/' ? '' : ' — Веб-стандарты';
+        return data.title + titleSuffix;
     },
 };

--- a/src/data/eleventyComputed.js
+++ b/src/data/eleventyComputed.js
@@ -1,0 +1,9 @@
+export default {
+    titleSuffix(data) {
+        return data.page.url === '/' ? '' : ' — Веб-стандарты';
+    },
+
+    pageTitle(data) {
+        return data.title + data.titleSuffix;
+    },
+};

--- a/src/includes/open-graph.njk
+++ b/src/includes/open-graph.njk
@@ -1,12 +1,12 @@
 <meta property="og:type" content="website">
-<meta property="og:title" content="{{ renderData.title or title }}{{ titleSuffix }}">
+<meta property="og:title" content="{{ pageTitle }}">
 <meta property="og:site_name" content="{{ podcastDescription or site.description }}">
 <meta property="og:description" content="{{ preview }}">
 <meta property="og:url" content="{{ site.paths.site }}{{ page.url }}">
 <meta property="og:image" content="{{ site.paths.social }}">
 
 <meta name="twitter:card" content="summary_large_image">
-<meta name="twitter:title" content="{{ renderData.title or title }}{{ titleSuffix }}">
+<meta name="twitter:title" content="{{ pageTitle }}">
 <meta name="twitter:description" content="{{ preview or site.description }}">
 <meta name="twitter:site" content="{{ site.paths.site }}{{ page.url }}">
 <meta name="twitter:image" content="{{ site.paths.social }}">

--- a/src/layouts/page.njk
+++ b/src/layouts/page.njk
@@ -1,15 +1,8 @@
 <!DOCTYPE html>
 <html class="page" lang="ru">
 <head>
-    {% if page.url == '/' %}
-        {% set isIndex = true %}
-    {% else %}
-        {% set titleSuffix = ' — Веб-стандарты' %}
-        {% set isIndex = false %}
-    {% endif %}
-
     <title>
-        {{ renderData.title or title }}{{ titleSuffix }}
+        {{ pageTitle }}
     </title>
 
     <meta charset="utf-8">


### PR DESCRIPTION
Правки:
- Заметил, что в `layouts/page.njk` есть неиспользуемая переменная `isIndex`.
- Удалил использование `renderData.title`, так как нигде не нашёл места его задания. Видимо, было в начале редизайна.
- Перенёс задание переменной `titleSuffix` в глобальное computed-поле, чтобы в самих шаблонах было меньше вычислений. Конечное задание `title` также перенёс в computed-поле `pageTitle(data) { return data.title + data.titleSuffix; }`.