### PR TITLE
Восстанавливает пробелы между именами ведущих на странице выпуска подкаста

### DIFF
--- a/src/styles/blocks/podcast.css
+++ b/src/styles/blocks/podcast.css
@@ -89,6 +89,10 @@
     display: inline;
 }
 
+.podcast__host:not(:last-child)::after {
+    content: ' ';
+}
+
 .podcast__player {
     position: sticky;
     top: 16px;


### PR DESCRIPTION
Делается в CSS, так как минификатор удаляет пробелы в HTML.