### PR TITLE
Меняет настройки HTML-минификатора для сохранения только значимых пробелов

### DIFF
--- a/src/eleventy-config/transforms.js
+++ b/src/eleventy-config/transforms.js
@@ -233,6 +233,9 @@ export default function(eleventyConfig) {
         eleventyConfig.addTransform('htmlmin', (content, outputPath) => {
             if (outputPath && outputPath.endsWith('.html')) {
                 return htmlmin.minify(content, {
+                    collapseWhitespace: true,
+                    collapseInlineTagWhitespace: true,
+                    conservativeCollapse: true,
                     minifyJS: true,
                     minifyCSS: true,
                 });


### PR DESCRIPTION
Добавляет настройки, указанные в [этом комментарии](https://github.com/web-standards-ru/web-standards.ru/pull/374#issuecomment-2408852005).

С ними, HTML выглядит, например, так:

```html
<ul class="podcast__hosts-list"> <li class="podcast__host"> Вадим Макеев,</li> <li class="podcast__host"> Никита Дубко,</li> <li class="podcast__host"> Юлия Миоцен,</li> <li class="podcast__host"> Алексей Симоненко,</li> <li class="podcast__host"> Андрей Мелихов</li> </ul>
```