### PR TITLE
Рефакторит загрузку данных подкаста в npm

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "markdown-it-multimd-table": "^4.2.3",
         "minify-xml": "^4.5.2",
         "node-w3c-validator": "^2.0.2",
-        "podcast": "github:web-standards-ru/podcast",
         "remark-cli": "^12.0.1",
         "remark-frontmatter": "^5.0.0",
         "remark-lint": "^10.0.0",
@@ -6828,13 +6827,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/podcast": {
-      "resolved": "git+ssh://git@github.com/web-standards-ru/podcast.git#0d3024f747d81658a6d1427cf7da8d6e4c12eddd",
-      "dev": true,
-      "engines": {
-        "node": "20"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -13,12 +13,10 @@
     "typograph": "remark",
     "html": "node-w3c-validator -i ./dist/**/*.html --exclude ./dist/**/demos/** -f lint -evH",
     "test": "npm run editorconfig && npm run stylelint && npm run markdown && npm run eslint",
-    "build": "cross-env-shell NODE_ENV=production \"rm -rf dist && eleventy\"",
+    "build": "npm run fetch-podcast-data && cross-env-shell NODE_ENV=production \"rm -rf dist && eleventy\"",
     "deploy": "cd dist && rsync --progress --archive --compress --delete . wst@web-standards.ru:/var/www/web-standards.ru/html/",
     "fetch-podcast-data": "npm install git://github.com/web-standards-ru/podcast.git#main --save=false --package-lock=false",
-    "postinstall": "npm run fetch-podcast-data",
-    "full": "npm run fetch-podcast-data && npm run build && npm run deploy",
-    "build-and-deploy": "npm run build && npm run deploy"
+    "postinstall": "npm run fetch-podcast-data"
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "build": "cross-env-shell NODE_ENV=production \"rm -rf dist && eleventy\"",
     "deploy": "cd dist && rsync --progress --archive --compress --delete . wst@web-standards.ru:/var/www/web-standards.ru/html/",
     "fetch-podcast-data": "npm install git://github.com/web-standards-ru/podcast.git#main --save=false --package-lock=false",
-    "postinstall": "npm run fetch-podcast-data"
+    "postinstall": "npm run fetch-podcast-data",
+    "full": "npm run fetch-podcast-data && npm run build && npm run deploy"
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "deploy": "cd dist && rsync --progress --archive --compress --delete . wst@web-standards.ru:/var/www/web-standards.ru/html/",
     "fetch-podcast-data": "npm install git://github.com/web-standards-ru/podcast.git#main --save=false --package-lock=false",
     "postinstall": "npm run fetch-podcast-data",
-    "full": "npm run fetch-podcast-data && npm run build && npm run deploy"
+    "full": "npm run fetch-podcast-data && npm run build && npm run deploy",
+    "build-and-deploy": "npm run build && npm run deploy"
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "typograph": "remark",
     "html": "node-w3c-validator -i ./dist/**/*.html --exclude ./dist/**/demos/** -f lint -evH",
     "test": "npm run editorconfig && npm run stylelint && npm run markdown && npm run eslint",
-    "build": "npm i && cross-env-shell NODE_ENV=production \"rm -rf dist && eleventy\"",
+    "build": "cross-env-shell NODE_ENV=production \"rm -rf dist && eleventy\"",
     "deploy": "cd dist && rsync --progress --archive --compress --delete . wst@web-standards.ru:/var/www/web-standards.ru/html/",
-    "postinstall": "npm install git://github.com/web-standards-ru/podcast.git#main --save=false --package-lock=false"
+    "fetch-podcast-data": "npm install git://github.com/web-standards-ru/podcast.git#main --save=false --package-lock=false",
+    "postinstall": "npm run fetch-podcast-data"
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",
@@ -40,7 +41,6 @@
     "markdown-it-multimd-table": "^4.2.3",
     "minify-xml": "^4.5.2",
     "node-w3c-validator": "^2.0.2",
-    "podcast": "github:web-standards-ru/podcast",
     "remark-cli": "^12.0.1",
     "remark-frontmatter": "^5.0.0",
     "remark-lint": "^10.0.0",


### PR DESCRIPTION
Сейчас есть такая проблема. Репозиторий подкаста загружается два раза при установке зависимостей. Один раз - так как он числится как зависимость, второй раз - в хуке `postinstall`, чтобы убедиться, что пришли новые данные, так как в `package-lock.json` может быть указатель на старые данные.

Предлагаю убрать явное упоминание подкаста как зависимости и оставить загрузку только в `postinstall`. Это позволит:
- загружать данные подкаста только один раз
- убрать "шум" в `package-lock.json` типа такого:  
  <img width="1081" alt="image" src="https://github.com/user-attachments/assets/cd77104a-2652-442a-a542-58b58cd190f1" />

Также увидел, что в `npm run build` была установка зависимостей. Как понял, это сделано, чтобы при локальных сборках всегда были новые данные подкаста? В любом случае, лучше вынести это оттуда и либо вызывать руками `npm run fetch-podcast-data && npm run build`, либо сделать для этого псевдоним типа `build-with-new-podcast-data`.