### PR TITLE
Правит "висячие" кнопки тултипов в заголовках

### DIFF
--- a/src/styles/blocks/content.css
+++ b/src/styles/blocks/content.css
@@ -29,6 +29,7 @@
     line-height: 1.2;
     letter-spacing: 0.08em;
     text-transform: uppercase;
+    text-wrap: balance;
 }
 
 .content strong {


### PR DESCRIPTION
Кнопка с тултипом в заголовках контента может переноситься отдельно:

<img width="586" alt="image" src="https://github.com/user-attachments/assets/da709e85-4ba9-4ab3-875f-bb9435596467" />

При добавлении `text-wrap: balance` выглядит лучше:

<img width="608" alt="image" src="https://github.com/user-attachments/assets/33d65168-1364-408a-8732-22663fdeddfd" />
