### PR TITLE
Правит внешние отступы блока дополнительных статей

### DIFF
--- a/src/styles/blocks/links.css
+++ b/src/styles/blocks/links.css
@@ -2,7 +2,6 @@
 
 .links {
     display: grid;
-    margin-top: -1px;
     padding: 16px 16px 24px;
     background-color: var(--token-color-links-background);
 }

--- a/src/styles/blocks/main.css
+++ b/src/styles/blocks/main.css
@@ -8,6 +8,18 @@
     padding-bottom: 10%;
 }
 
+@media (width < 800px) {
+    .main__related-articles {
+        margin-bottom: -1px;
+    }
+}
+
+@media (800px <= width < 1024px) {
+    .main__related-articles {
+        margin-bottom: 100px;
+    }
+}
+
 @media (min-width: 800px) {
     .main__section {
         padding-right: 24px;

--- a/src/styles/blocks/related-articles.css
+++ b/src/styles/blocks/related-articles.css
@@ -1,12 +1,7 @@
-.related-articles {
-    max-width: 700px;
-    margin: 0 auto;
-}
-
-@media (min-width: 1240px) {
+@media (width < 1024px) {
     .related-articles {
-        max-width: none;
-        margin: 0;
+        max-width: 700px;
+        margin-inline: auto;
     }
 }
 


### PR DESCRIPTION
Этот PR устраняет "прилипание" блока статей "Ещё" к футеру на размерах экрана 800-1024 (fix #272) и немного рефакторит стили с связанных блоках.

Другую часть issue, связанную с переполнением, нужно решать в рамках этой задачи https://github.com/web-standards-ru/web-standards.ru/issues/139.