### PR TITLE
Удаляет хак для обхода бага для генерации gif

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,6 @@
         "remark-lint-ordered-list-marker-value": "^4.0.0",
         "remark-lint-strong-marker": "^4.0.0",
         "remark-lint-unordered-list-marker-style": "^4.0.0",
-        "sharp": "^0.33.5",
         "stylelint": "^16.13.0",
         "stylelint-order": "^6.0.4",
         "typograf": "^7.4.1"

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "remark-lint-ordered-list-marker-value": "^4.0.0",
     "remark-lint-strong-marker": "^4.0.0",
     "remark-lint-unordered-list-marker-style": "^4.0.0",
-    "sharp": "^0.33.5",
     "stylelint": "^16.13.0",
     "stylelint-order": "^6.0.4",
     "typograf": "^7.4.1"

--- a/src/eleventy-config/transforms.js
+++ b/src/eleventy-config/transforms.js
@@ -4,7 +4,6 @@ import htmlmin from 'html-minifier-terser';
 import minifyXml from 'minify-xml';
 import { parseHTML } from 'linkedom';
 import Image from '@11ty/eleventy-img';
-import sharp from 'sharp';
 
 Image.concurrency = os.availableParallelism ? os.availableParallelism() : os.cpus().length;
 
@@ -30,14 +29,6 @@ async function processImage({ imageElement, inputPath, options, attributes }) {
 
     const tempElement = imageElement.ownerDocument.createElement('div');
     tempElement.innerHTML = Image.generateHTML(imageStats, imageAttributes);
-
-    // Задаём размеры сами, так как для Gif они вычисляются некорректно
-    // https://github.com/11ty/eleventy-img/pull/182
-    const sharpImageMetaData = await sharp(inputPath).metadata();
-    const width = imageElement.getAttribute('width') ?? sharpImageMetaData.width;
-    const height = imageElement.getAttribute('height') ?? sharpImageMetaData.pageHeight ?? sharpImageMetaData.height;
-    const newImage = tempElement.querySelector('img');
-    Object.assign(newImage, { width, height });
 
     imageElement.replaceWith(tempElement.firstElementChild);
 }


### PR DESCRIPTION
В библиотеке `sharp` была [особенность](https://github.com/11ty/eleventy-img/pull/182) с вычислением размеров для gif-изображений, которая правилась в этом [PR](https://github.com/web-standards-ru/web-standards.ru/pull/350).

Дополнительно `sharp` удалён из явных зависимостей, так как не используется больше напрямую, а тянется внутри `@11ty/eleventy-img`.