### PR TITLE
Добавляет кэш изображений в Github Actions

### DIFF
--- a/.github/workflows/check-image-cache.yml
+++ b/.github/workflows/check-image-cache.yml
@@ -1,0 +1,25 @@
+name: Check Image Cache
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * 4'
+
+jobs:
+  check-images-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Cache images
+        id: images-cache
+        uses: actions/cache@v4
+        env:
+          cache-name: cache-images
+        with:
+          path: '.cache/@11ty/_images'
+          enableCrossOsArchive: true
+          key: images-${{ hashFiles('src/articles/**/*.png', 'src/articles/**/*.jpg', 'src/articles/**/*.svg', 'src/articles/**/*.gif', 'src/people/**/*.jpg') }}
+      - name: check cache
+        if: steps.images-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: echo "Кэш изображений не найден

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,13 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version-file: package.json
+      - name: Images cache
+        id: images-cache
+        uses: actions/cache@v4
+        with:
+          path: '.cache/@11ty/_images'
+          enableCrossOsArchive: true
+          key: images-${{ hashFiles('src/articles/**/*.png', 'src/articles/**/*.jpg', 'src/articles/**/*.svg', 'src/articles/**/*.gif', 'src/people/**/*.jpg') }}
       # Setup key
       - name: Setup key
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 dist
+.cache


### PR DESCRIPTION
Обработка изображений занимает большую часть вермени сборки, при этом изображения не меняются, а Антарктида тает. Поэтому есть идея хранить обработанные изображения в кэше Github Actions.

Техника основана на статье Зака Лазермана https://www.zachleat.com/web/faster-builds-with-eleventy-img/

Процесс следующий:
- Eleventy Image складывает все изображения при "первоначальной" (без кэша) сборке в папку `.cache/@11ty/_images`
- Добавляем эту папку в кэш Actions по ключу `images-${{ hashFiles('src/articles/**/*.png', 'src/articles/**/*.jpg', 'src/articles/**/*.svg', 'src/articles/**/*.gif', 'src/people/**/*.jpg') }}`. В идеале этот ключ должен ещё зависеть от настроек обработки изображений - форматов, размеров и пр. Но я пока упустил этот момент для простоты.
- При повторной сборке восстанавливаем этот кэш. Eleventy Image смотрит на наличие изображений в папке `.cache/@11ty/_images`. Затем после сборки просто копирует их в свою `dist/_images`.

Ещё момент - кэш хранится не больше недели с момента последнего обращения к нему. Поэтому я добавил action, который раз в неделю по четвергам проверяет кэш.  Правда, я пока не уверен, будет ли это засчитываться как обращение.

