### PR TITLE
Добавляет Cross-Origin Resource Policy для MP3, фида и обложки

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -20,7 +20,10 @@ web-standards.ru {
         path /podcast/cover.png /podcast/episodes/*.mp3 /podcast/feed/
     }
 
-    header @cors Access-Control-Allow-Origin *
+    header @cors {
+        Access-Control-Allow-Origin *
+        Cross-Origin-Resource-Policy cross-origin
+    }
 
     handle_errors {
         @404 expression {http.error.status_code} == 404


### PR DESCRIPTION
Добавление заголовка `Access-Control-Allow-Origin: *` не помогло починить воспроизведение в веб-версии PocketCasts
Девтулзы советуют использовать заголовок `Cross-Origin-Resource-Policy: cross-origin`

---

<img width="922" height="285" alt="image" src="https://github.com/user-attachments/assets/02628e47-25e8-44af-af44-313373240e61" />
