### PR TITLE
Правит закругления у плеера в Firefox

### DIFF
--- a/src/styles/blocks/player.css
+++ b/src/styles/blocks/player.css
@@ -33,6 +33,7 @@
 .player__audio {
     width: 100%;
     height: 40px;
+    overflow: hidden;
     border-radius: 20px;
     filter: drop-shadow(
         2px 2px 4px rgba(0, 0, 0, 0.2)


### PR DESCRIPTION
Рядом с круглыми кнопками смотрится аккуратнее

До:
![image.png](https://github.com/user-attachments/assets/416d8e04-23d2-4674-acf6-523f0dc40478)

После:

![image.png](https://github.com/user-attachments/assets/8f281c51-5a58-405c-b6d3-845359c89615)

fix: #431