### PR TITLE
Добавляет crossorigin на preload для шрифтов

### DIFF
--- a/src/layouts/page.njk
+++ b/src/layouts/page.njk
@@ -9,10 +9,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <meta name="description" content="{{ preview or site.description }}">
 
-    <link rel="preload" fetchpriority="high" href="/fonts/dewi-regular-cyrillic.woff2" as="font" type="font/woff2">
-    <link rel="preload" fetchpriority="high" href="/fonts/dewi-bold-cyrillic.woff2" as="font" type="font/woff2">
-    <link rel="preload" fetchpriority="high" href="/fonts/dewi-regular-latin.woff2" as="font" type="font/woff2">
-    <link rel="preload" fetchpriority="high" href="/fonts/dewi-bold-latin.woff2" as="font" type="font/woff2">
+    <link rel="preload" fetchpriority="high" href="/fonts/dewi-regular-cyrillic.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" fetchpriority="high" href="/fonts/dewi-bold-cyrillic.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" fetchpriority="high" href="/fonts/dewi-regular-latin.woff2" as="font" type="font/woff2" crossorigin>
+    <link rel="preload" fetchpriority="high" href="/fonts/dewi-bold-latin.woff2" as="font" type="font/woff2" crossorigin>
 
     <meta name="theme-color" content="#81c36d" media="(prefers-color-scheme: light)">
     <meta name="theme-color" content="#273238" media="(prefers-color-scheme: dark)">


### PR DESCRIPTION
Раньше не замечал, но браузеры стали писать: 

```
A preload for 'https://web-standards.ru/fonts/dewi-regular-latin.woff2' is found, 
but is not used because the request credentials mode does not match. 
Consider taking a look at crossorigin attribute.
```

Возможно, это стало после добавления заголовка `cross-origin-resource-policy`.

@pepelsbey, ты был прав – нужно добавлять атрибут crossorigin на preload для  шрифтов, даже если запросы идут в рамках одного домена.

Объяснение (https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Attributes/rel/preload#cors-enabled_fetches
): атрибут crossorigin нужен не потому, что запрос «кросс‑доменный», а потому, что запросы шрифтов всегда обрабатываются браузером в CORS‑режиме